### PR TITLE
Validationlogic. Changed context view in report and added JavaDoc for exceptions.

### DIFF
--- a/validationlogic/src/main/java/org/verapdf/validation/report/XMLValidationReport.java
+++ b/validationlogic/src/main/java/org/verapdf/validation/report/XMLValidationReport.java
@@ -7,7 +7,6 @@ import javax.xml.transform.stream.*;
 
 import org.verapdf.validation.report.model.Check;
 import org.verapdf.validation.report.model.Rule;
-import org.verapdf.validation.report.model.Summary;
 import org.w3c.dom.*;
 
 import org.verapdf.validation.report.model.ValidationInfo;
@@ -27,8 +26,8 @@ public class XMLValidationReport {
 
     /**
      * Creates tree of xml tags for validation report
-     * @param info --- validation info model to be writed
-     * @param doc --- document used for writing xml in further
+     * @param info - validation info model to be writed
+     * @param doc - document used for writing xml in further
      * @return root element of the xml structure
      */
     public static Element makeXMLTree(ValidationInfo info, Document doc){
@@ -89,12 +88,7 @@ public class XMLValidationReport {
                 location.setAttribute("level", che.getLocation().getAttr_level());
                 Element context = doc.createElement("context");
 
-                StringBuffer buffer = new StringBuffer(che.getLocation().getContext().get(0));
-                for (int i = 1; i < che.getLocation().getContext().size(); ++i){
-                    buffer.append(" - " + che.getLocation().getContext().get(i));
-                }
-
-                context.appendChild(doc.createTextNode(buffer.toString()));
+                context.appendChild(doc.createTextNode(che.getLocation().getContext()));
 
                 location.appendChild(context);
                 check.appendChild(location);
@@ -134,7 +128,16 @@ public class XMLValidationReport {
         return validationInfo;
     }
 
-    public static void writeXMLValidationReport(ValidationInfo info, String path) throws ParserConfigurationException, TransformerException, FileNotFoundException {
+    /**
+     * Write the given validation info into xml formatted report.
+     * @param info - validation info model to be writed
+     * @param path - the path for output the resulting document. Path have to ends with file name with extension.
+     * @throws ParserConfigurationException - if a DocumentBuilder cannot be created which satisfies the configuration requested.
+     * @throws TransformerFactoryConfigurationError - thrown in case of service configuration error or if the implementation is not available or cannot be instantiated or when it is not possible to create a Transformer instance.
+     * @throws TransformerException - if an unrecoverable error occurs during the course of the transformation or
+     * @throws FileNotFoundException - if the file with path {@code path} exists but is a directory rather than a regular file, does not exist but cannot be created, or cannot be opened for any other reason
+     */
+    public static void writeXMLValidationReport(ValidationInfo info, String path) throws ParserConfigurationException, TransformerFactoryConfigurationError, TransformerException, FileNotFoundException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
         DocumentBuilder builder = factory.newDocumentBuilder();

--- a/validationlogic/src/main/java/org/verapdf/validation/report/model/CheckLocation.java
+++ b/validationlogic/src/main/java/org/verapdf/validation/report/model/CheckLocation.java
@@ -11,9 +11,9 @@ import java.util.List;
  */
 public class CheckLocation {
     private String attr_level;
-    private List<String> context;
+    private String context;
 
-    public CheckLocation(String attr_level, List<String> context) {
+    public CheckLocation(String attr_level, String context) {
         this.attr_level = attr_level;
         this.context = context;
     }
@@ -28,7 +28,7 @@ public class CheckLocation {
     /**
      * @return list of edges' names which used for come to the checked object
      */
-    public List<String> getContext() {
+    public String getContext() {
         return context;
     }
 }

--- a/validationlogic/src/test/java/org/verapdf/validation/logic/TestCosDict.java
+++ b/validationlogic/src/test/java/org/verapdf/validation/logic/TestCosDict.java
@@ -38,7 +38,7 @@ public class TestCosDict implements CosDict {
     @Override
     public List<String> getLinks() {
         List<String> res = new ArrayList<>();
-        res.add("CosDict");
+        res.add("keys");
         res.add("CosInteger");
         res.add("Object");
         return res;
@@ -47,7 +47,7 @@ public class TestCosDict implements CosDict {
     @Override
     public List<? extends Object> getLinkedObjects(String s) {
         switch (s){
-            case "CosDict":
+            case "keys":
                 return cosDicts;
             case "CosInteger":
                 return cosIntegers;

--- a/validationlogic/src/test/java/org/verapdf/validation/logic/ValidationLogicTest.java
+++ b/validationlogic/src/test/java/org/verapdf/validation/logic/ValidationLogicTest.java
@@ -21,7 +21,7 @@ public class ValidationLogicTest {
     @Test
     public void test() throws Exception {
 
-        TestPDAnnot pda1 = new TestPDAnnot("pdatestLOOOOOL","pda1");
+        TestPDAnnot pda1 = new TestPDAnnot("pdatestFailedVersion","pda1");
         TestPDAnnot pda2 = new TestPDAnnot("pdatest","pda2");
         List<PDAnnot> lspd = new ArrayList<>();
         lspd.add(pda1);
@@ -58,8 +58,8 @@ public class ValidationLogicTest {
         assertEquals(info.getResult().getSummary().getAttr_passedRules(), 1);
         assertEquals(info.getResult().getSummary().getAttr_failedRules(), 3);
 
-        assertEquals(info.getResult().getSummary().getAttr_passedChecks(), 3);
-        assertEquals(info.getResult().getSummary().getAttr_failedChecks(), 3);
+        assertEquals(info.getResult().getSummary().getAttr_passedChecks(), 4);
+        assertEquals(info.getResult().getSummary().getAttr_failedChecks(), 4);
 
     }
 

--- a/validationprofileparser/src/main/java/org/verapdf/validation/profile/parser/ValidationProfileParser.java
+++ b/validationprofileparser/src/main/java/org/verapdf/validation/profile/parser/ValidationProfileParser.java
@@ -302,9 +302,9 @@ public class ValidationProfileParser {
      * Parses validation profile xml.
      * @param resourcePath - Path to the file for parse.
      * @return Validation profile represent in Java classes.
-     * @throws ParserConfigurationException
-     * @throws SAXException
-     * @throws IOException
+     * @throws ParserConfigurationException - if a DocumentBuilder cannot be created which satisfies the configuration requested.
+     * @throws IOException - If any IO errors occur.
+     * @throws SAXException - If any parse errors occur.
      */
     public static ValidationProfile parseValidationProfile(String resourcePath) throws ParserConfigurationException, SAXException, IOException {
         return parseValidationProfile(new File(resourcePath));
@@ -314,11 +314,11 @@ public class ValidationProfileParser {
      *
      * @param resourceFile - File for parse.
      * @return Validation profile represent in Java classes.
-     * @throws IOException
-     * @throws SAXException
-     * @throws ParserConfigurationException
+     * @throws ParserConfigurationException - if a DocumentBuilder cannot be created which satisfies the configuration requested.
+     * @throws IOException - If any IO errors occur.
+     * @throws SAXException - If any parse errors occur.
      */
-    public static ValidationProfile parseValidationProfile(File resourceFile) throws IOException, SAXException, ParserConfigurationException {
+    public static ValidationProfile parseValidationProfile(File resourceFile) throws ParserConfigurationException, SAXException, IOException {
         ValidationProfileParser parser = new ValidationProfileParser(resourceFile);
         return parser.profile;
     }


### PR DESCRIPTION
1) Previous context was list of link types separated by " - ". Now it's list of link names with indices (for each link) and separated by "/". 
2) Previously all objects checked just 1 time (without looking at their context). Now it checking any object with unique path to it (by id). With preventing loops.
3) Added javadoc for all exceptions.