### PR TITLE
Single XML doc, update to core profiles and bug fixes

### DIFF
--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  *
  */
-@XmlJavaTypeAdapter(TestAssertionImpl.Adapter.class)
+@XmlJavaTypeAdapter(ValidationResultImpl.Adapter.class)
 public interface ValidationResult {
     /**
      * @return true if the PDF/A document complies with the PDF/A specification

--- a/core/src/main/java/org/verapdf/pdfa/results/package-info.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/package-info.java
@@ -12,7 +12,7 @@
  * @version 0.7
  * @since 0.7
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/ValidationProfile", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/ValidationProfile")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.verapdf.pdfa.results;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/org/verapdf/pdfa/results/package-info.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/package-info.java
@@ -12,5 +12,9 @@
  * @version 0.7
  * @since 0.7
  */
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.verapdf.pdfa.results;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
 

--- a/core/src/main/java/org/verapdf/pdfa/validation/package-info.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/package-info.java
@@ -10,7 +10,7 @@
  * @version 0.7
  * @since 0.7
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/ValidationProfile", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/ValidationProfile")}, elementFormDefault = XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.verapdf.pdfa.validation;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/org/verapdf/pdfa/validation/package-info.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/package-info.java
@@ -10,7 +10,7 @@
  * @version 0.7
  * @since 0.7
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/ValidationProfile", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/ValidationProfile")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.verapdf.pdfa.validation;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-1A.xml
+++ b/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-1A.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_1_A">
-    <details creator="veraPDF Consortium" created="2016-02-24T13:27:57.304+03:00">
+    <details creator="veraPDF Consortium" created="2016-02-25T10:23:11.133+03:00">
         <name>PDF/A-1A validation profile</name>
         <description>Validation rules against ISO 19005-1:2005, Cor.1:2007 and Cor.2:2011</description>
     </details>
@@ -10,7 +10,7 @@
             <id specification="ISO_19005_1" clause="6.1.2" testNumber="1"/>
             <description>The % character of the file header shall occur at byte offset 0 of the file. 
 			The first line of a PDF file is a header identifying the version of the PDF specification to which the file conforms</description>
-            <test>pdfHeaderCompliesPDFA</test>
+            <test>headerOffset == 0 &amp;&amp; /%PDF-\d\.\d/.test(header)</test>
             <error>
                 <message>File header does not start at byte offset 0 or does not correctly identify the version of the PDF document</message>
                 <arguments/>
@@ -54,7 +54,7 @@
         <rule object="CosDocument">
             <id specification="ISO_19005_1" clause="6.1.3" testNumber="3"/>
             <description>No data shall follow the last end-of-file marker except a single optional end-of-line marker.</description>
-            <test>eofCompliesPDFA</test>
+            <test>postEOFDataSize == 0</test>
             <error>
                 <message>Data is present after the last end-of-file marker</message>
                 <arguments/>
@@ -77,7 +77,7 @@
         <rule object="CosXRef">
             <id specification="ISO_19005_1" clause="6.1.4" testNumber="1"/>
             <description>In a cross reference subsection header the starting object number and the range shall be separated by a single SPACE character (20h)</description>
-            <test>xrefHeaderSpacingsComplyPDFA</test>
+            <test>subsectionHeaderSpaceSeparated == true</test>
             <error>
                 <message>Spacings of subsection headers in the cross reference table do not comply PDF/A specification</message>
                 <arguments/>
@@ -129,7 +129,7 @@
             <id specification="ISO_19005_1" clause="6.1.7" testNumber="2"/>
             <description>The stream keyword shall be followed either by a CARRIAGE RETURN (0Dh) and LINE FEED (0Ah) character sequence
 			or by a single LINE FEED character. The endstream keyword shall be preceded by an EOL marker</description>
-            <test>spacingCompliesPDFA</test>
+            <test>streamKeywordCRLFCompliant == true &amp;&amp; endstreamKeywordEOLCompliant == true</test>
             <error>
                 <message>Spacings of keywords 'stream' and 'endstream' do not comply PDF/A specification</message>
                 <arguments/>
@@ -183,7 +183,7 @@
         <rule object="CosFileSpecification">
             <id specification="ISO_19005_1" clause="6.1.11" testNumber="1"/>
             <description>A file specification dictionary, as defined in PDF 3.10.2, shall not contain the EF key</description>
-            <test>EF == null</test>
+            <test>EF_size == 0</test>
             <error>
                 <message>A file specification dictionary contains the EF key</message>
                 <arguments/>
@@ -243,11 +243,11 @@
         <rule object="CosName">
             <id specification="ISO_19005_1" clause="6.1.12" testNumber="4"/>
             <description>Maximum length of a name (in bytes) is 127</description>
-            <test>origLength &lt;= 127</test>
+            <test>internalRepresentation.length() &lt;= 127</test>
             <error>
                 <message>Maximum length of a Name (127) exceeded</message>
                 <arguments>
-                    <argument>origLength</argument>
+                    <argument>internalRepresentation.length()</argument>
                 </arguments>
             </error>
             <references>

--- a/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-1B.xml
+++ b/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-1B.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_1_B">
-    <details creator="veraPDF Consortium" created="2016-02-24T13:26:18.816+03:00">
+    <details creator="veraPDF Consortium" created="2016-02-25T10:23:53.982+03:00">
         <name>PDF/A-1B validation profile</name>
         <description>Validation rules against ISO 19005-1:2005, Cor.1:2007 and Cor.2:2011</description>
     </details>
@@ -23,7 +23,7 @@
             <id specification="ISO_19005_1" clause="6.1.2" testNumber="2"/>
             <description>The file header line shall be immediately followed by a comment consisting of a % character followed by at 
 			least four characters, each of whose encoded byte values shall have a decimal value greater than 127</description>
-            <test>binaryHeaderComplyPDFA</test>
+            <test>headerByte1 &gt; 127 &amp;&amp; headerByte2 &gt; 127 &amp;&amp; headerByte3 &gt; 127 &amp;&amp; headerByte4 &gt; 127</test>
             <error>
                 <message>Binary comment in the file header is missing or does not comply PDF/A requirements</message>
                 <arguments/>
@@ -54,7 +54,7 @@
         <rule object="CosDocument">
             <id specification="ISO_19005_1" clause="6.1.3" testNumber="3"/>
             <description>No data shall follow the last end-of-file marker except a single optional end-of-line marker.</description>
-            <test>eofCompliesPDFA</test>
+            <test>postEOFDataSize == 0</test>
             <error>
                 <message>Data is present after the last end-of-file marker</message>
                 <arguments/>
@@ -107,7 +107,7 @@
         <rule object="CosString">
             <id specification="ISO_19005_1" clause="6.1.6" testNumber="2"/>
             <description>All non-white-space characters in hexadecimal strings shall be in the range 0 to 9, A to F or a to f</description>
-            <test>(isHex != true) || isHexSymbols</test>
+            <test>(isHex != true) || containsOnlyHex</test>
             <error>
                 <message>Hexadecimal string contains non-white-space characters outside the range 0 to 9, A to F or a to f</message>
                 <arguments/>
@@ -183,7 +183,7 @@
         <rule object="CosFileSpecification">
             <id specification="ISO_19005_1" clause="6.1.11" testNumber="1"/>
             <description>A file specification dictionary, as defined in PDF 3.10.2, shall not contain the EF key</description>
-            <test>EF == null</test>
+            <test>EF_size == 0</test>
             <error>
                 <message>A file specification dictionary contains the EF key</message>
                 <arguments/>

--- a/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-2B.xml
+++ b/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-2B.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_2_B">
-    <details creator="veraPDF Consortium" created="2016-02-24T13:30:09.726+03:00">
+    <details creator="veraPDF Consortium" created="2016-02-25T10:25:47.738+03:00">
         <name>PDF/A-2B validation profile</name>
         <description>Validation rules against ISO 19005-2:2011</description>
     </details>
     <hash></hash>
     <rules>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.2" testNumber="1"/>
             <description>The file header shall begin at byte zero and shall consist of &quot;%PDF-1.n&quot; followed by a single EOL marker, 
 			where 'n' is a single digit number between 0 (30h) and 7 (37h)</description>
             <test>headerOffset == 0 &amp;&amp; /%PDF-1\.[0-7]/.test(header)</test>
@@ -18,7 +18,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.2" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.2" testNumber="2"/>
             <description>The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four bytes, each of whose encoded 
 			byte values shall have a decimal value greater than 127</description>
             <test>headerByte1 &gt; 127 &amp;&amp; headerByte2 &gt; 127 &amp;&amp; headerByte3 &gt; 127 &amp;&amp; headerByte4 &gt; 127</test>
@@ -29,7 +29,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.3" testNumber="1"/>
             <description>The file trailer dictionary shall contain the ID keyword whose value shall be File Identifiers as defined in ISO 32000-1:2008, 14.4</description>
             <test>lastID != null</test>
             <error>
@@ -41,7 +41,7 @@
             </references>
         </rule>
         <rule object="CosTrailer">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.3" testNumber="2"/>
             <description>The keyword Encrypt shall not be used in the trailer dictionary</description>
             <test>isEncrypted != true</test>
             <error>
@@ -51,7 +51,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.1.3" testNumber="3"/>
             <description>No data can follow the last end-of-file marker except a single optional end-of-line marker as described in ISO 32000-1:2008, 7.5.5.</description>
             <test>postEOFDataSize == 0</test>
             <error>
@@ -63,7 +63,7 @@
             </references>
         </rule>
         <rule object="CosXRef">
-            <id specification="ISO_19005_1" clause="6.1.4" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.4" testNumber="2"/>
             <description>The xref keyword and the cross-reference subsection header shall be separated by a single EOL marker</description>
             <test>xrefEOLMarkersComplyPDFA</test>
             <error>
@@ -73,7 +73,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.6" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.6" testNumber="1"/>
             <description>Hexadecimal strings shall contain an even number of non-white-space characters</description>
             <test>(isHex != true) || hexCount % 2 == 0</test>
             <error>
@@ -83,7 +83,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.6" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.6" testNumber="2"/>
             <description>A hexadecimal string is written as a sequence of hexadecimal digits (0–9 and either A–F or a–f)</description>
             <test>(isHex != true) || containsOnlyHex</test>
             <error>
@@ -93,7 +93,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.7" testNumber="1"/>
             <description>The value of the Length key specified in the stream dictionary shall match the number of bytes in the file following the LINE FEED (0Ah) character
 			after the stream keyword and preceding the EOL marker before the endstream keyword.</description>
             <test>isLengthCorrect</test>
@@ -104,7 +104,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.7" testNumber="2"/>
             <description>The stream keyword shall be followed either by a CARRIAGE RETURN (0Dh) and LINE FEED (0Ah) character sequence or by a single LINE FEED (0Ah) 
 			character. The endstream keyword shall be preceded by an EOL marker.</description>
             <test>streamKeywordCRLFCompliant &amp;&amp; endstreamKeywordEOLCompliant</test>
@@ -115,7 +115,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.1.7" testNumber="3"/>
             <description>A stream dictionary shall not contain the F, FFilter, or FDecodeParams keys</description>
             <test>F == null &amp;&amp; FFilter == null &amp;&amp; FDecodeParms == null</test>
             <error>
@@ -125,7 +125,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.1.7" testNumber="4"/>
             <description>All standard stream filters listed in ISO 32000-1:2008, 7.4, Table 6 may be used, with the exception of LZWDecode.</description>
             <test>filters == null || filters.indexOf(&quot;LZWDecode&quot;) == -1</test>
             <error>
@@ -135,7 +135,7 @@
             <references/>
         </rule>
         <rule object="CosUnicodeName">
-            <id specification="ISO_19005_1" clause="6.1.8" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.8" testNumber="1"/>
             <description>Font names, names of colourants in Separation and DeviceN colour spaces, and structure type names, after expansion of character sequences escaped with 
 			a NUMBER SIGN (23h), if any, shall be valid UTF-8 character sequences.</description>
             <test>isValidUtf8 == true</test>
@@ -148,7 +148,7 @@
             </references>
         </rule>
         <rule object="CosIndirect">
-            <id specification="ISO_19005_1" clause="6.1.9" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.9" testNumber="1"/>
             <description>The object number and generation number shall be separated by a single white-space character. The generation number and obj keyword shall be 
 			separated by a single white-space character. The object number and endobj keyword shall each be preceded by an EOL marker. The obj and endobj
 			keywords shall each be followed by an EOL marker.</description>
@@ -160,7 +160,7 @@
             <references/>
         </rule>
         <rule object="PDInlineImage">
-            <id specification="ISO_19005_1" clause="6.1.10" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.10" testNumber="1"/>
             <description>The value of the F key in the Inline Image dictionary shall not be LZW, LZWDecode, Crypt, a value not listed in ISO 32000-1:2008, Table 6, 
 			or an array containing any such value.</description>
             <test>F == null || (F.indexOf(&quot;LZW&quot;) == -1 &amp;&amp; F.indexOf(&quot;Crypt&quot;) == -1)</test>
@@ -171,7 +171,7 @@
             <references/>
         </rule>
         <rule object="CosInteger">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="1"/>
             <description>A conforming file shall not contain any integer greater than 2147483647. A conforming file shall not contain any integer less than -2147483648.</description>
             <test>(intValue &lt;= 2147483647) &amp;&amp; (intValue &gt;= -2147483648)</test>
             <error>
@@ -181,7 +181,7 @@
             <references/>
         </rule>
         <rule object="CosReal">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="2"/>
             <description>A conforming file shall not contain any real number outside the range of +/-3.403 x 10^38</description>
             <test>(realValue &gt;= -3.403e+38) &amp;&amp; (realValue &lt;= 3.403e+38)</test>
             <error>
@@ -191,7 +191,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="3"/>
             <description>A conforming file shall not contain any string longer than 32767 bytes.</description>
             <test>value.length() &lt; 32767</test>
             <error>
@@ -201,7 +201,7 @@
             <references/>
         </rule>
         <rule object="CosName">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="4"/>
             <description>A conforming file shall not contain any name longer than 127 bytes.</description>
             <test>internalRepresentation.length() &lt;= 127</test>
             <error>
@@ -211,7 +211,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="7"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="7"/>
             <description>A conforming file shall not contain more than 8388607 indirect objects</description>
             <test>nrIndirects &lt;= 8388607</test>
             <error>
@@ -221,7 +221,7 @@
             <references/>
         </rule>
         <rule object="Op_q_gsave">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="8"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="8"/>
             <description>A conforming file shall not nest q/Q pairs by more than 28 nesting levels</description>
             <test>nestingLevel &lt;= 28</test>
             <error>
@@ -231,7 +231,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceN">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="9"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="9"/>
             <description>A conforming file shall not contain a DeviceN colour space with more than 32 colourants.</description>
             <test>nrComponents &lt;= 32</test>
             <error>
@@ -241,7 +241,7 @@
             <references/>
         </rule>
         <rule object="CIDGlyph">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="10"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
             <test>CID &lt;= 65535</test>
             <error>
@@ -251,7 +251,7 @@
             <references/>
         </rule>
         <rule object="CosBBox">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="11"/>
+            <id specification="ISO_19005_2" clause="6.1.13" testNumber="11"/>
             <description>The size of any of the page boundaries described in ISO 32000-1:2008, 14.11.2 shall not be less than 3 units
 			in either direction, nor shall it be greater than 14 400 units in either direction.</description>
             <test>top - bottom &gt;= 3 &amp;&amp; top - bottom &lt;= 14400 &amp;&amp; right - left &gt;= 3 &amp;&amp; right - left &lt;= 14400</test>
@@ -262,7 +262,7 @@
             <references/>
         </rule>
         <rule object="Op_Undefined">
-            <id specification="ISO_19005_1" clause="6.2.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.2" testNumber="1"/>
             <description>Content streams shall not contain any operators not defined in ISO 32000-1 even if such operators are bracketed 
 			by the BX/EX compatibility operators.</description>
             <test>false</test>
@@ -273,7 +273,7 @@
             <references/>
         </rule>
         <rule object="ICCOutputProfile">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.3" testNumber="1"/>
             <description>The profile stream that is the value of the DestOutputProfile key shall either be an output profile (Device Class = &quot;prtr&quot;) or a monitor profile 
 			(Device Class = &quot;mntr&quot;). The profiles shall have a colour space of either &quot;GRAY&quot;, &quot;RGB&quot;, or &quot;CMYK&quot;.</description>
             <test>(deviceClass == &quot;prtr&quot; || deviceClass == &quot;mntr&quot;) &amp;&amp; (colorSpace == &quot;RGB &quot; || colorSpace == &quot;CMYK&quot; || colorSpace == &quot;GRAY&quot;) &amp;&amp; version &lt; 5.0</test>
@@ -286,7 +286,7 @@
             </references>
         </rule>
         <rule object="PDOutputIntent">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.3" testNumber="2"/>
             <description>If a file's OutputIntents array contains more than one entry, as might be the case where a file is compliant
 			with this part of ISO 19005 and at the same time with PDF/X-4 or PDF/E-1, then all entries that contain a
 			DestOutputProfile key shall have as the value of that key the same indirect object, which shall be a valid ICC
@@ -299,7 +299,7 @@
             <references/>
         </rule>
         <rule object="PDOutputIntent">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.3" testNumber="3"/>
             <description>In addition, the DestOutputProfileRef key, as defined in ISO 15930-7:2010, Annex A, shall not be present in any PDF/X OutputIntent.</description>
             <test>DestOutputProfileRef_size == 0</test>
             <error>
@@ -311,7 +311,7 @@
             </references>
         </rule>
         <rule object="ICCInputProfile">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="1"/>
             <description>The profile that forms the stream of an ICCBased colour space shall conform to ICC.1:1998-09, ICC.1:2001-12, ICC.1:2003-09 or ISO 15076-1.</description>
             <test>(deviceClass == &quot;prtr&quot; || deviceClass == &quot;mntr&quot; || deviceClass == &quot;scnr&quot; || deviceClass == &quot;spac&quot;) &amp;&amp; 
 			(colorSpace == &quot;RGB &quot; || colorSpace == &quot;CMYK&quot; || colorSpace == &quot;GRAY&quot; || colorSpace == &quot;LAB &quot;) &amp;&amp; version &lt; 5.0</test>
@@ -324,7 +324,7 @@
             </references>
         </rule>
         <rule object="PDDeviceRGB">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="2"/>
             <description>DeviceRGB shall only be used if a device independent DefaultRGB colour space has been set when the DeviceRGB colour space is used,
 			or if the file has a PDF/A OutputIntent that contains an RGB destination profile.</description>
             <test>gOutputCS != null &amp;&amp; gOutputCS == &quot;RGB &quot;</test>
@@ -335,7 +335,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceCMYK">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="3"/>
             <description>DeviceCMYK shall only be used if a device independent DefaultCMYK colour space has been set or if a DeviceN-based DefaultCMYK colour space
 			has been set when the DeviceCMYK colour space is used or the file has a PDF/A OutputIntent that contains a CMYK destination profile.</description>
             <test>gOutputCS != null &amp;&amp; gOutputCS == &quot;CMYK&quot;</test>
@@ -346,7 +346,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceGray">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="4"/>
             <description>DeviceGray shall only be used if a device independent DefaultGray colour space has been set when the DeviceGray colour space is used,
 			or if a PDF/A OutputIntent is present.</description>
             <test>gOutputCS != null</test>
@@ -357,7 +357,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceN">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="5"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="5"/>
             <description>For any spot colour used in a DeviceN or NChannel colour space, an entry in the Colorants dictionary shall be present.</description>
             <test>areColorantsPresent == true</test>
             <error>
@@ -369,7 +369,7 @@
             </references>
         </rule>
         <rule object="PDSeparation">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="6"/>
+            <id specification="ISO_19005_2" clause="6.2.4" testNumber="6"/>
             <description>All Separation arrays within a single PDF/A-2 file (including those in Colorants dictionaries) that have the
 			same name shall have the same tintTransform and alternateSpace. In evaluating equivalence, the PDF
 			objects shall be compared, rather than the computational result of the use of those PDF objects. Compression
@@ -382,7 +382,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.5" testNumber="1"/>
             <description>An ExtGState dictionary shall not contain the TR key</description>
             <test>TR == null</test>
             <error>
@@ -392,7 +392,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.5" testNumber="2"/>
             <description>An ExtGState dictionary shall not contain the TR2 key with a value other than Default</description>
             <test>TR2 == null || TR2 == &quot;Default&quot;</test>
             <error>
@@ -402,7 +402,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.5" testNumber="3"/>
             <description>An ExtGState dictionary shall not contain the HTP key</description>
             <test>HTP_size == 0</test>
             <error>
@@ -412,7 +412,7 @@
             <references/>
         </rule>
         <rule object="PDHalftone">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.5" testNumber="4"/>
             <description>All halftones in a conforming PDF/A-2 file shall have the value 1 or 5 for the HalftoneType key.</description>
             <test>HalftoneType != null &amp;&amp; (HalftoneType == 1 || HalftoneType == 5)</test>
             <error>
@@ -422,7 +422,7 @@
             <references/>
         </rule>
         <rule object="PDHalftone">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="5"/>
+            <id specification="ISO_19005_2" clause="6.2.5" testNumber="5"/>
             <description>Halftones in a conforming PDF/A-2 file shall not contain a HalftoneName key.</description>
             <test>HalftoneName == null</test>
             <error>
@@ -432,7 +432,7 @@
             <references/>
         </rule>
         <rule object="CosRenderingIntent">
-            <id specification="ISO_19005_1" clause="6.2.6" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.6" testNumber="1"/>
             <description>Where a rendering intent is specified, its value shall be one of the four values defined in ISO 32000-1:2008,
 			Table 70: RelativeColorimetric, AbsoluteColorimetric, Perceptual or Saturation.</description>
             <test>internalRepresentation == &quot;RelativeColorimetric&quot; || internalRepresentation == &quot;AbsoluteColorimetric&quot; || internalRepresentation == &quot;Perceptual&quot; || internalRepresentation == &quot;Saturation&quot;</test>
@@ -443,7 +443,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="1"/>
             <description>An Image dictionary shall not contain the Alternates key</description>
             <test>Alternates_size == 0</test>
             <error>
@@ -453,7 +453,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="2"/>
             <description>An Image dictionary shall not contain the OPI key</description>
             <test>OPI_size == 0</test>
             <error>
@@ -463,7 +463,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.8" testNumber="3"/>
             <description>If an Image dictionary contains the Interpolate key, its value shall be false. 
 			For an inline image, the I key shall have a value of false.</description>
             <test>Interpolate == false</test>
@@ -474,7 +474,7 @@
             <references/>
         </rule>
         <rule object="PDXForm">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.9" testNumber="1"/>
             <description>A form XObject dictionary shall not contain any of the following: - the OPI key; - the Subtype2 key with a value of PS; - the PS key.</description>
             <test>(Subtype2 == null || Subtype2 != &quot;PS&quot;) &amp;&amp; PS_size == 0 &amp;&amp; OPI_size == 0</test>
             <error>
@@ -484,7 +484,7 @@
             <references/>
         </rule>
         <rule object="PDXForm">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.9" testNumber="2"/>
             <description>A conforming file shall not contain any reference XObjects</description>
             <test>Ref_size == 0</test>
             <error>
@@ -494,7 +494,7 @@
             <references/>
         </rule>
         <rule object="PDXObject">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.9" testNumber="3"/>
             <description>A conforming file shall not contain any PostScript XObjects</description>
             <test>Subtype != &quot;PS&quot;</test>
             <error>
@@ -504,7 +504,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.10" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.10" testNumber="1"/>
             <description>Only blend modes that are specified in ISO 32000-1:2008 shall be used for the value of the BM key in an extended graphic state dictionary.</description>
             <test>BM == null || BM == &quot;Normal&quot; || BM == &quot;Compatible&quot; || BM == &quot;Multiply&quot; || BM == &quot;Screen&quot; || BM == &quot;Overlay&quot; || BM == &quot;Darken&quot; ||
 			BM == &quot;Lighten&quot; || BM == &quot;ColorDodge&quot; || BM == &quot;ColorBurn&quot; || BM == &quot;HardLight&quot; || BM == &quot;SoftLight&quot; || BM == &quot;Difference&quot; || BM == &quot;Exclusion&quot; ||
@@ -518,7 +518,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="1"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to
 			the provisions in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Type - name - (Required) The type of PDF object that this dictionary describes; must be Font for a font dictionary</description>
@@ -535,7 +535,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="2"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Subtype - name - (Required) The type of font; must be &quot;Type1&quot; for Type 1 fonts, &quot;MMType1&quot; for multiple master fonts, &quot;TrueType&quot; for TrueType fonts
@@ -556,7 +556,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="3"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions. 
 			BaseFont - name - (Required) The PostScript name of the font</description>
@@ -572,7 +572,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="4"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			FirstChar - integer - (Required except for the standard 14 fonts) The first character code defined in the font's Widths array</description>
@@ -587,7 +587,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="5"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="5"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			FirstChar - integer - (Required except for the standard 14 fonts) The first character code defined in the font's Widths array</description>
@@ -602,7 +602,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="6"/>
+            <id specification="ISO_19005_2" clause="6.2.11.2" testNumber="6"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Widths - array - (Required except for the standard 14 fonts; indirect reference preferred) An array of (LastChar − FirstChar + 1) widths</description>
@@ -617,7 +617,7 @@
             </references>
         </rule>
         <rule object="PDType0Font">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.3" testNumber="1"/>
             <description>For any given composite (Type 0) font within a conforming file, the CIDSystemInfo entry in its CIDFont dictionary and its Encoding dictionary 
 			shall have the following relationship: 
 			- If the Encoding key in the Type 0 font dictionary is Identity-H or Identity-V, any values of Registry, Ordering, 
@@ -632,7 +632,7 @@
             <references/>
         </rule>
         <rule object="PDCIDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.11.3" testNumber="2"/>
             <description>ISO 32000-1:2008, 9.7.4, Table 117 requires that all embedded Type 2 CIDFonts in the CIDFont dictionary shall contain a 
 			CIDToGIDMap entry that shall be a stream mapping from CIDs to glyph indices or the name Identity, as described in ISO 32000-1:2008, 9.7.4, Table 117.</description>
             <test>Subtype != &quot;CIDFontType2&quot; || CIDToGIDMap != null</test>
@@ -645,7 +645,7 @@
             </references>
         </rule>
         <rule object="PDCMap">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.11.3" testNumber="3"/>
             <description>All CMaps used within a PDF/A-2 file, except those listed in ISO 32000-1:2008, 9.7.5.2, Table 118, shall be embedded in that file as described 
 			in ISO 32000-1:2008, 9.7.5.</description>
             <test>CMapName == &quot;Identity-H&quot; || CMapName == &quot;Identity-V&quot; || CMapName == &quot;GB-EUC-H&quot; || CMapName == &quot;GB-EUC-V&quot; ||
@@ -673,7 +673,7 @@
             </references>
         </rule>
         <rule object="CMapFile">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.11.3" testNumber="4"/>
             <description>For those CMaps that are embedded, the integer value of the WMode entry in the CMap dictionary shall be identical to the WMode value
 			in the embedded CMap stream.</description>
             <test>WMode == dictWMode</test>
@@ -684,7 +684,7 @@
             <references/>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.4" testNumber="1"/>
             <description>The font programs for all fonts used for rendering within a conforming file shall be embedded within that file, as defined in ISO 32000-1:2008, 9.9.</description>
             <test>Subtype == &quot;Type3&quot; || Subtype == &quot;Type0&quot; || fontFile_size == 1</test>
             <error>
@@ -696,7 +696,7 @@
             </references>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.11.4" testNumber="2"/>
             <description>Embedded fonts shall define all glyphs referenced for rendering within the conforming file.</description>
             <test>isGlyphPresent == true</test>
             <error>
@@ -706,7 +706,7 @@
             <references/>
         </rule>
         <rule object="PDType1Font">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.11.4" testNumber="3"/>
             <description>If the FontDescriptor dictionary of an embedded Type 1 font contains a CharSet string, then it shall list the character names of all glyphs
 			present in the font program, regardless of whether a glyph in the font is referenced or used by the PDF or not.</description>
             <test>CharSet == null || charSetListsAllGlyphs == true</test>
@@ -717,7 +717,7 @@
             <references/>
         </rule>
         <rule object="PDCIDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.11.4" testNumber="4"/>
             <description>If the FontDescriptor dictionary of an embedded CID font contains a CIDSet stream, then it shall identify all CIDs which are present in the font program,
 			regardless of whether a CID in the font is referenced or used by the PDF or not.</description>
             <test>CIDSet_size == 0 || cidSetListsAllGlyphs == true</test>
@@ -728,7 +728,7 @@
             <references/>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.5" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.5" testNumber="1"/>
             <description>For every font embedded in a conforming file and used for rendering, the glyph width information in the font dictionary and in the embedded 
 			font program shall be consistent.</description>
             <test>isWidthConsistent == true</test>
@@ -739,7 +739,7 @@
             <references/>
         </rule>
         <rule object="TrueTypeFontProgram">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.6" testNumber="1"/>
             <description>For all non-symbolic TrueType fonts used for rendering, the embedded TrueType font program shall contain one or several non-symbolic 
 			cmap entries such that all necessary glyph lookups can be carried out.</description>
             <test>isSymbolic == true || nrCmaps &gt;= 1</test>
@@ -750,7 +750,7 @@
             <references/>
         </rule>
         <rule object="PDTrueTypeFont">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.2.11.6" testNumber="2"/>
             <description>No non-symbolic TrueType font shall define a Differences array unless all of the glyph names in
 			the Differences array are listed in the Adobe Glyph List and the embedded font program contains at least the
 			Microsoft Unicode (3,1 – Platform ID=3, Encoding ID=1) encoding in the &quot;cmap&quot; table.</description>
@@ -763,7 +763,7 @@
             <references/>
         </rule>
         <rule object="PDTrueTypeFont">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.2.11.6" testNumber="3"/>
             <description>Symbolic TrueType fonts shall not contain an Encoding entry in the font dictionary</description>
             <test>isSymbolic == false || Encoding == null</test>
             <error>
@@ -773,7 +773,7 @@
             <references/>
         </rule>
         <rule object="TrueTypeFontProgram">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="4"/>
+            <id specification="ISO_19005_2" clause="6.2.11.6" testNumber="4"/>
             <description>Symbolic TrueType fonts shall not contain an Encoding entry in the font dictionary, and the &quot;cmap&quot; table in the embedded font program
 			shall either contain exactly one encoding or it shall contain, at least, the Microsoft Symbol (3,0 – Platform ID=3, Encoding ID=0) encoding.</description>
             <test>isSymbolic == false || nrCmaps == 1 || cmap30Present == true</test>
@@ -784,7 +784,7 @@
             <references/>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.8" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.2.11.8" testNumber="1"/>
             <description>A PDF/A-2 compliant document shall not contain a reference to the .notdef glyph from any of the text showing
 			operators, regardless of text rendering mode, in any content stream.</description>
             <test>name != &quot;.notdef&quot;</test>
@@ -795,7 +795,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.1" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.3.1" testNumber="1"/>
             <description>Annotation types not defined in ISO 32000-1 shall not be permitted. Additionally, the 3D, Sound, Screen and Movie types shall not be permitted.</description>
             <test>Subtype == &quot;Text&quot; || Subtype == &quot;Link&quot; || Subtype == &quot;FreeText&quot; || Subtype == &quot;Line&quot; || 
 			Subtype == &quot;Square&quot; || Subtype == &quot;Circle&quot; || Subtype == &quot;Polygon&quot; || Subtype == &quot;PolyLine&quot; ||
@@ -812,7 +812,7 @@
             </references>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.3.2" testNumber="1"/>
             <description>Except for annotation dictionaries whose Subtype value is Popup, all annotation dictionaries shall contain the F key.</description>
             <test>Subtype == &quot;Popup&quot; || F != null</test>
             <error>
@@ -822,7 +822,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.3.2" testNumber="2"/>
             <description>If present, the F key's Print flag bit shall be set to 1 and its Hidden, Invisible, ToggleNoView, and NoView flag bits shall be set to 0.</description>
             <test>F == null || ((F &amp; 1) == 0 &amp;&amp; (F &amp; 2) == 0 &amp;&amp; (F &amp; 4) == 4 &amp;&amp; (F &amp; 32) == 0 &amp;&amp; (F &amp; 256) == 0)</test>
             <error>
@@ -832,7 +832,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.3.2" testNumber="3"/>
             <description>Text annotations should set the NoZoom and NoRotate flag bits of the F key to 1.</description>
             <test>Subtype != &quot;Text&quot; || (F != null &amp;&amp; (F &amp; 8) == 1 &amp;&amp; (F &amp; 16) == 1)</test>
             <error>
@@ -842,7 +842,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.3" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.3.3" testNumber="1"/>
             <description>Every annotation (including those whose Subtype value is Widget, as used for form fields), except for the two cases listed below,
 			shall have at least one appearance dictionary:
 			- annotations where the value of the Rect key consists of an array where value 1 is equal to value 3 and value 2 is equal to value 4;
@@ -855,7 +855,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.3" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.3.3" testNumber="2"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>
@@ -867,7 +867,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.4.1" testNumber="1"/>
             <description>A Widget annotation dictionary or Field dictionary shall not contain the A or AA keys.</description>
             <test>Subtype != &quot;Widget&quot; || (A_size == 0 &amp;&amp; AA_size == 0)</test>
             <error>
@@ -877,7 +877,7 @@
             <references/>
         </rule>
         <rule object="PDFormField">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.4.1" testNumber="2"/>
             <description>A Widget annotation dictionary or Field dictionary shall not contain the A or AA keys.</description>
             <test>AA_size == 0</test>
             <error>
@@ -887,7 +887,7 @@
             <references/>
         </rule>
         <rule object="PDAcroForm">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.4.1" testNumber="3"/>
             <description>The NeedAppearances flag of the interactive form dictionary shall either not be present or shall be false.</description>
             <test>NeedAppearances == null || NeedAppearances == false</test>
             <error>
@@ -897,7 +897,7 @@
             <references/>
         </rule>
         <rule object="PDAcroForm">
-            <id specification="ISO_19005_1" clause="6.4.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.4.2" testNumber="1"/>
             <description>The document's interactive form dictionary that forms the value of the AcroForm key in the document's Catalog of a PDF/A-2 file, 
 			if present, shall not contain the XFA key.</description>
             <test>XFA_size == 0</test>
@@ -908,7 +908,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.4.2" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.4.2" testNumber="2"/>
             <description>A document's Catalog shall not contain the NeedsRendering key.</description>
             <test>NeedsRendering == false</test>
             <error>
@@ -918,7 +918,7 @@
             <references/>
         </rule>
         <rule object="PDAction">
-            <id specification="ISO_19005_1" clause="6.5.1" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.5.1" testNumber="1"/>
             <description>The Launch, Sound, Movie, ResetForm, ImportData, Hide, SetOCGState, Rendition, Trans, GoTo3DView and JavaScript actions shall not be permitted. 
 			Additionally, the deprecated set-state and noop actions shall not be permitted.</description>
             <test>S == &quot;GoTo&quot; || S == &quot;GoToR&quot; || S == &quot;GotToE&quot; || S == &quot;Thread&quot; || S == &quot;URI&quot; || S == &quot;Named&quot; || S == &quot;SubmitForm&quot;</test>
@@ -931,7 +931,7 @@
             </references>
         </rule>
         <rule object="PDNamedAction">
-            <id specification="ISO_19005_1" clause="6.5.1" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.5.1" testNumber="2"/>
             <description>Named actions other than NextPage, PrevPage, FirstPage, and LastPage shall not be permitted.</description>
             <test>N == &quot;NextPage&quot; || N == &quot;PrevPage&quot; || N == &quot;FirstPage&quot; || N == &quot;LastPage&quot;</test>
             <error>
@@ -943,7 +943,7 @@
             </references>
         </rule>
         <rule object="PDDocument">
-            <id specification="ISO_19005_1" clause="6.5.2" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.5.2" testNumber="1"/>
             <description>The document's Catalog shall not include an AA entry for an additional-actions dictionary.</description>
             <test>AA_size == 0</test>
             <error>
@@ -953,7 +953,7 @@
             <references/>
         </rule>
         <rule object="PDPage">
-            <id specification="ISO_19005_1" clause="6.5.2" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.5.2" testNumber="2"/>
             <description>The Page dictionary shall not include an AA entry for an additional-actions dictionary.</description>
             <test>AA_size == 0</test>
             <error>
@@ -963,7 +963,7 @@
             <references/>
         </rule>
         <rule object="PDFAIdSchema">
-            <id specification="ISO_19005_1" clause="6.6.4" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.6.4" testNumber="2"/>
             <description>The value of pdfaid:part shall be the part number of ISO 19005 to which the file conforms. Files prepared in
  			compliance with this part of ISO 19005 shall use a value of 2.</description>
             <test>part == 2</test>
@@ -976,7 +976,7 @@
             <references/>
         </rule>
         <rule object="PDFAIdSchema">
-            <id specification="ISO_19005_1" clause="6.6.4" testNumber="3"/>
+            <id specification="ISO_19005_2" clause="6.6.4" testNumber="3"/>
             <description>Level B conforming file shall specify the value of pdfaid:conformance as B.</description>
             <test>conformance == &quot;B&quot;</test>
             <error>
@@ -988,7 +988,7 @@
             <references/>
         </rule>
         <rule object="EmbeddedFile">
-            <id specification="ISO_19005_1" clause="6.8" testNumber="1"/>
+            <id specification="ISO_19005_2" clause="6.8" testNumber="1"/>
             <description>A file specification dictionary, as defined in ISO 32000-1:2008, 7.11.3, may contain the EF key, provided that the embedded file is
 			compliant with either ISO 19005-1 or this part of ISO 19005.</description>
             <test>isValidPDFA12 == true</test>
@@ -999,7 +999,7 @@
             <references/>
         </rule>
         <rule object="CosFileSpecification">
-            <id specification="ISO_19005_1" clause="6.8" testNumber="2"/>
+            <id specification="ISO_19005_2" clause="6.8" testNumber="2"/>
             <description>The file specification dictionary for an embedded file shall contain the F and UF keys</description>
             <test>EF_size == 0 || (F != null &amp;&amp; UF != null)</test>
             <error>

--- a/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-3B.xml
+++ b/core/src/main/resources/org/verapdf/pdfa/validation/PDFA-3B.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile xmlns="http://www.verapdf.org/ValidationProfile" flavour="PDFA_3_B">
-    <details creator="veraPDF Consortium" created="2016-02-24T13:32:46.494+03:00">
+    <details creator="veraPDF Consortium" created="2016-02-25T10:21:55.260+03:00">
         <name>PDF/A-3B validation profile</name>
         <description>Validation rules against ISO 19005-3:2012</description>
     </details>
     <hash></hash>
     <rules>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.2" testNumber="1"/>
             <description>The file header shall begin at byte zero and shall consist of &quot;%PDF-1.n&quot; followed by a single EOL marker, 
 			where 'n' is a single digit number between 0 (30h) and 7 (37h)</description>
             <test>headerOffset == 0 &amp;&amp; /%PDF-1\.[0-7]/.test(header)</test>
@@ -18,7 +18,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.2" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.2" testNumber="2"/>
             <description>The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four bytes, each of whose encoded 
 			byte values shall have a decimal value greater than 127</description>
             <test>headerByte1 &gt; 127 &amp;&amp; headerByte2 &gt; 127 &amp;&amp; headerByte3 &gt; 127 &amp;&amp; headerByte4 &gt; 127</test>
@@ -29,7 +29,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.3" testNumber="1"/>
             <description>The file trailer dictionary shall contain the ID keyword whose value shall be File Identifiers as defined in ISO 32000-1:2008, 14.4</description>
             <test>lastID != null</test>
             <error>
@@ -41,7 +41,7 @@
             </references>
         </rule>
         <rule object="CosTrailer">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.3" testNumber="2"/>
             <description>The keyword Encrypt shall not be used in the trailer dictionary</description>
             <test>isEncrypted != true</test>
             <error>
@@ -51,7 +51,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.3" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.1.3" testNumber="3"/>
             <description>No data can follow the last end-of-file marker except a single optional end-of-line marker as described in ISO 32000-1:2008, 7.5.5.</description>
             <test>postEOFDataSize == 0</test>
             <error>
@@ -63,7 +63,7 @@
             </references>
         </rule>
         <rule object="CosXRef">
-            <id specification="ISO_19005_1" clause="6.1.4" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.4" testNumber="2"/>
             <description>The xref keyword and the cross-reference subsection header shall be separated by a single EOL marker</description>
             <test>xrefEOLMarkersComplyPDFA</test>
             <error>
@@ -73,7 +73,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.6" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.6" testNumber="1"/>
             <description>Hexadecimal strings shall contain an even number of non-white-space characters</description>
             <test>(isHex != true) || hexCount % 2 == 0</test>
             <error>
@@ -83,7 +83,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.6" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.6" testNumber="2"/>
             <description>A hexadecimal string is written as a sequence of hexadecimal digits (0–9 and either A–F or a–f)</description>
             <test>(isHex != true) || containsOnlyHex</test>
             <error>
@@ -93,7 +93,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.7" testNumber="1"/>
             <description>The value of the Length key specified in the stream dictionary shall match the number of bytes in the file following the LINE FEED (0Ah) character
 			after the stream keyword and preceding the EOL marker before the endstream keyword.</description>
             <test>isLengthCorrect</test>
@@ -104,7 +104,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.7" testNumber="2"/>
             <description>The stream keyword shall be followed either by a CARRIAGE RETURN (0Dh) and LINE FEED (0Ah) character sequence or by a single LINE FEED (0Ah) 
 			character. The endstream keyword shall be preceded by an EOL marker.</description>
             <test>streamKeywordCRLFCompliant &amp;&amp; endstreamKeywordEOLCompliant</test>
@@ -115,7 +115,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.1.7" testNumber="3"/>
             <description>A stream dictionary shall not contain the F, FFilter, or FDecodeParams keys</description>
             <test>F == null &amp;&amp; FFilter == null &amp;&amp; FDecodeParms == null</test>
             <error>
@@ -125,7 +125,7 @@
             <references/>
         </rule>
         <rule object="CosStream">
-            <id specification="ISO_19005_1" clause="6.1.7" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.1.7" testNumber="4"/>
             <description>All standard stream filters listed in ISO 32000-1:2008, 7.4, Table 6 may be used, with the exception of LZWDecode.</description>
             <test>filters == null || filters.indexOf(&quot;LZWDecode&quot;) == -1</test>
             <error>
@@ -135,7 +135,7 @@
             <references/>
         </rule>
         <rule object="CosUnicodeName">
-            <id specification="ISO_19005_1" clause="6.1.8" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.8" testNumber="1"/>
             <description>Font names, names of colourants in Separation and DeviceN colour spaces, and structure type names, after expansion of character sequences escaped with 
 			a NUMBER SIGN (23h), if any, shall be valid UTF-8 character sequences.</description>
             <test>isValidUtf8 == true</test>
@@ -148,7 +148,7 @@
             </references>
         </rule>
         <rule object="CosIndirect">
-            <id specification="ISO_19005_1" clause="6.1.9" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.9" testNumber="1"/>
             <description>The object number and generation number shall be separated by a single white-space character. The generation number and obj keyword shall be 
 			separated by a single white-space character. The object number and endobj keyword shall each be preceded by an EOL marker. The obj and endobj
 			keywords shall each be followed by an EOL marker.</description>
@@ -160,7 +160,7 @@
             <references/>
         </rule>
         <rule object="PDInlineImage">
-            <id specification="ISO_19005_1" clause="6.1.10" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.10" testNumber="1"/>
             <description>The value of the F key in the Inline Image dictionary shall not be LZW, LZWDecode, Crypt, a value not listed in ISO 32000-1:2008, Table 6, 
 			or an array containing any such value.</description>
             <test>F == null || (F.indexOf(&quot;LZW&quot;) == -1 &amp;&amp; F.indexOf(&quot;Crypt&quot;) == -1)</test>
@@ -171,7 +171,7 @@
             <references/>
         </rule>
         <rule object="CosInteger">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="1"/>
             <description>A conforming file shall not contain any integer greater than 2147483647. A conforming file shall not contain any integer less than -2147483648.</description>
             <test>(intValue &lt;= 2147483647) &amp;&amp; (intValue &gt;= -2147483648)</test>
             <error>
@@ -181,7 +181,7 @@
             <references/>
         </rule>
         <rule object="CosReal">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="2"/>
             <description>A conforming file shall not contain any real number outside the range of +/-3.403 x 10^38</description>
             <test>(realValue &gt;= -3.403e+38) &amp;&amp; (realValue &lt;= 3.403e+38)</test>
             <error>
@@ -191,7 +191,7 @@
             <references/>
         </rule>
         <rule object="CosString">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="3"/>
             <description>A conforming file shall not contain any string longer than 32767 bytes.</description>
             <test>value.length() &lt; 32767</test>
             <error>
@@ -201,7 +201,7 @@
             <references/>
         </rule>
         <rule object="CosName">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="4"/>
             <description>A conforming file shall not contain any name longer than 127 bytes.</description>
             <test>internalRepresentation.length() &lt;= 127</test>
             <error>
@@ -211,7 +211,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="7"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="7"/>
             <description>A conforming file shall not contain more than 8388607 indirect objects</description>
             <test>nrIndirects &lt;= 8388607</test>
             <error>
@@ -221,7 +221,7 @@
             <references/>
         </rule>
         <rule object="Op_q_gsave">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="8"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="8"/>
             <description>A conforming file shall not nest q/Q pairs by more than 28 nesting levels</description>
             <test>nestingLevel &lt;= 28</test>
             <error>
@@ -231,7 +231,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceN">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="9"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="9"/>
             <description>A conforming file shall not contain a DeviceN colour space with more than 32 colourants.</description>
             <test>nrComponents &lt;= 32</test>
             <error>
@@ -241,7 +241,7 @@
             <references/>
         </rule>
         <rule object="CIDGlyph">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="10"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="10"/>
             <description>A conforming file shall not contain a CID value greater than 65535.</description>
             <test>CID &lt;= 65535</test>
             <error>
@@ -251,7 +251,7 @@
             <references/>
         </rule>
         <rule object="CosBBox">
-            <id specification="ISO_19005_1" clause="6.1.13" testNumber="11"/>
+            <id specification="ISO_19005_3" clause="6.1.13" testNumber="11"/>
             <description>The size of any of the page boundaries described in ISO 32000-1:2008, 14.11.2 shall not be less than 3 units
 			in either direction, nor shall it be greater than 14 400 units in either direction.</description>
             <test>top - bottom &gt;= 3 &amp;&amp; top - bottom &lt;= 14400 &amp;&amp; right - left &gt;= 3 &amp;&amp; right - left &lt;= 14400</test>
@@ -262,7 +262,7 @@
             <references/>
         </rule>
         <rule object="Op_Undefined">
-            <id specification="ISO_19005_1" clause="6.2.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.2" testNumber="1"/>
             <description>Content streams shall not contain any operators not defined in ISO 32000-1 even if such operators are bracketed 
 			by the BX/EX compatibility operators.</description>
             <test>false</test>
@@ -273,7 +273,7 @@
             <references/>
         </rule>
         <rule object="ICCOutputProfile">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.3" testNumber="1"/>
             <description>The profile stream that is the value of the DestOutputProfile key shall either be an output profile (Device Class = &quot;prtr&quot;) or a monitor profile 
 			(Device Class = &quot;mntr&quot;). The profiles shall have a colour space of either &quot;GRAY&quot;, &quot;RGB&quot;, or &quot;CMYK&quot;.</description>
             <test>(deviceClass == &quot;prtr&quot; || deviceClass == &quot;mntr&quot;) &amp;&amp; (colorSpace == &quot;RGB &quot; || colorSpace == &quot;CMYK&quot; || colorSpace == &quot;GRAY&quot;) &amp;&amp; version &lt; 5.0</test>
@@ -286,7 +286,7 @@
             </references>
         </rule>
         <rule object="PDOutputIntent">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.3" testNumber="2"/>
             <description>If a file's OutputIntents array contains more than one entry, as might be the case where a file is compliant
 			with this part of ISO 19005 and at the same time with PDF/X-4 or PDF/E-1, then all entries that contain a
 			DestOutputProfile key shall have as the value of that key the same indirect object, which shall be a valid ICC
@@ -299,7 +299,7 @@
             <references/>
         </rule>
         <rule object="PDOutputIntent">
-            <id specification="ISO_19005_1" clause="6.2.3" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.3" testNumber="3"/>
             <description>In addition, the DestOutputProfileRef key, as defined in ISO 15930-7:2010, Annex A, shall not be present in any PDF/X OutputIntent.</description>
             <test>DestOutputProfileRef_size == 0</test>
             <error>
@@ -311,7 +311,7 @@
             </references>
         </rule>
         <rule object="ICCInputProfile">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="1"/>
             <description>The profile that forms the stream of an ICCBased colour space shall conform to ICC.1:1998-09, ICC.1:2001-12, ICC.1:2003-09 or ISO 15076-1.</description>
             <test>(deviceClass == &quot;prtr&quot; || deviceClass == &quot;mntr&quot; || deviceClass == &quot;scnr&quot; || deviceClass == &quot;spac&quot;) &amp;&amp; 
 			(colorSpace == &quot;RGB &quot; || colorSpace == &quot;CMYK&quot; || colorSpace == &quot;GRAY&quot; || colorSpace == &quot;LAB &quot;) &amp;&amp; version &lt; 5.0</test>
@@ -324,7 +324,7 @@
             </references>
         </rule>
         <rule object="PDDeviceRGB">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="2"/>
             <description>DeviceRGB shall only be used if a device independent DefaultRGB colour space has been set when the DeviceRGB colour space is used,
 			or if the file has a PDF/A OutputIntent that contains an RGB destination profile.</description>
             <test>gOutputCS != null &amp;&amp; gOutputCS == &quot;RGB &quot;</test>
@@ -335,7 +335,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceCMYK">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="3"/>
             <description>DeviceCMYK shall only be used if a device independent DefaultCMYK colour space has been set or if a DeviceN-based DefaultCMYK colour space
 			has been set when the DeviceCMYK colour space is used or the file has a PDF/A OutputIntent that contains a CMYK destination profile.</description>
             <test>gOutputCS != null &amp;&amp; gOutputCS == &quot;CMYK&quot;</test>
@@ -346,7 +346,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceGray">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="4"/>
             <description>DeviceGray shall only be used if a device independent DefaultGray colour space has been set when the DeviceGray colour space is used,
 			or if a PDF/A OutputIntent is present.</description>
             <test>gOutputCS != null</test>
@@ -357,7 +357,7 @@
             <references/>
         </rule>
         <rule object="PDDeviceN">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="5"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="5"/>
             <description>For any spot colour used in a DeviceN or NChannel colour space, an entry in the Colorants dictionary shall be present.</description>
             <test>areColorantsPresent == true</test>
             <error>
@@ -369,7 +369,7 @@
             </references>
         </rule>
         <rule object="PDSeparation">
-            <id specification="ISO_19005_1" clause="6.2.4" testNumber="6"/>
+            <id specification="ISO_19005_3" clause="6.2.4" testNumber="6"/>
             <description>All Separation arrays within a single PDF/A-2 file (including those in Colorants dictionaries) that have the
 			same name shall have the same tintTransform and alternateSpace. In evaluating equivalence, the PDF
 			objects shall be compared, rather than the computational result of the use of those PDF objects. Compression
@@ -382,7 +382,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.5" testNumber="1"/>
             <description>An ExtGState dictionary shall not contain the TR key</description>
             <test>TR == null</test>
             <error>
@@ -392,7 +392,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.5" testNumber="2"/>
             <description>An ExtGState dictionary shall not contain the TR2 key with a value other than Default</description>
             <test>TR2 == null || TR2 == &quot;Default&quot;</test>
             <error>
@@ -402,7 +402,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.5" testNumber="3"/>
             <description>An ExtGState dictionary shall not contain the HTP key</description>
             <test>HTP_size == 0</test>
             <error>
@@ -412,7 +412,7 @@
             <references/>
         </rule>
         <rule object="PDHalftone">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.5" testNumber="4"/>
             <description>All halftones in a conforming PDF/A-2 file shall have the value 1 or 5 for the HalftoneType key.</description>
             <test>HalftoneType != null &amp;&amp; (HalftoneType == 1 || HalftoneType == 5)</test>
             <error>
@@ -422,7 +422,7 @@
             <references/>
         </rule>
         <rule object="PDHalftone">
-            <id specification="ISO_19005_1" clause="6.2.5" testNumber="5"/>
+            <id specification="ISO_19005_3" clause="6.2.5" testNumber="5"/>
             <description>Halftones in a conforming PDF/A-2 file shall not contain a HalftoneName key.</description>
             <test>HalftoneName == null</test>
             <error>
@@ -432,7 +432,7 @@
             <references/>
         </rule>
         <rule object="CosRenderingIntent">
-            <id specification="ISO_19005_1" clause="6.2.6" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.6" testNumber="1"/>
             <description>Where a rendering intent is specified, its value shall be one of the four values defined in ISO 32000-1:2008,
 			Table 70: RelativeColorimetric, AbsoluteColorimetric, Perceptual or Saturation.</description>
             <test>internalRepresentation == &quot;RelativeColorimetric&quot; || internalRepresentation == &quot;AbsoluteColorimetric&quot; || internalRepresentation == &quot;Perceptual&quot; || internalRepresentation == &quot;Saturation&quot;</test>
@@ -443,7 +443,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="1"/>
             <description>An Image dictionary shall not contain the Alternates key</description>
             <test>Alternates_size == 0</test>
             <error>
@@ -453,7 +453,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="2"/>
             <description>An Image dictionary shall not contain the OPI key</description>
             <test>OPI_size == 0</test>
             <error>
@@ -463,7 +463,7 @@
             <references/>
         </rule>
         <rule object="PDXImage">
-            <id specification="ISO_19005_1" clause="6.2.8" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.8" testNumber="3"/>
             <description>If an Image dictionary contains the Interpolate key, its value shall be false. 
 			For an inline image, the I key shall have a value of false.</description>
             <test>Interpolate == false</test>
@@ -474,7 +474,7 @@
             <references/>
         </rule>
         <rule object="PDXForm">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.9" testNumber="1"/>
             <description>A form XObject dictionary shall not contain any of the following: - the OPI key; - the Subtype2 key with a value of PS; - the PS key.</description>
             <test>(Subtype2 == null || Subtype2 != &quot;PS&quot;) &amp;&amp; PS_size == 0 &amp;&amp; OPI_size == 0</test>
             <error>
@@ -484,7 +484,7 @@
             <references/>
         </rule>
         <rule object="PDXForm">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.9" testNumber="2"/>
             <description>A conforming file shall not contain any reference XObjects</description>
             <test>Ref_size == 0</test>
             <error>
@@ -494,7 +494,7 @@
             <references/>
         </rule>
         <rule object="PDXObject">
-            <id specification="ISO_19005_1" clause="6.2.9" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.9" testNumber="3"/>
             <description>A conforming file shall not contain any PostScript XObjects</description>
             <test>Subtype != &quot;PS&quot;</test>
             <error>
@@ -504,7 +504,7 @@
             <references/>
         </rule>
         <rule object="PDExtGState">
-            <id specification="ISO_19005_1" clause="6.2.10" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.10" testNumber="1"/>
             <description>Only blend modes that are specified in ISO 32000-1:2008 shall be used for the value of the BM key in an extended graphic state dictionary.</description>
             <test>BM == null || BM == &quot;Normal&quot; || BM == &quot;Compatible&quot; || BM == &quot;Multiply&quot; || BM == &quot;Screen&quot; || BM == &quot;Overlay&quot; || BM == &quot;Darken&quot; ||
 			BM == &quot;Lighten&quot; || BM == &quot;ColorDodge&quot; || BM == &quot;ColorBurn&quot; || BM == &quot;HardLight&quot; || BM == &quot;SoftLight&quot; || BM == &quot;Difference&quot; || BM == &quot;Exclusion&quot; ||
@@ -518,7 +518,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="1"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to
 			the provisions in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Type - name - (Required) The type of PDF object that this dictionary describes; must be Font for a font dictionary</description>
@@ -535,7 +535,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="2"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Subtype - name - (Required) The type of font; must be &quot;Type1&quot; for Type 1 fonts, &quot;MMType1&quot; for multiple master fonts, &quot;TrueType&quot; for TrueType fonts
@@ -556,7 +556,7 @@
             </references>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="3"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions. 
 			BaseFont - name - (Required) The PostScript name of the font</description>
@@ -572,7 +572,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="4"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			FirstChar - integer - (Required except for the standard 14 fonts) The first character code defined in the font's Widths array</description>
@@ -587,7 +587,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="5"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="5"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			FirstChar - integer - (Required except for the standard 14 fonts) The first character code defined in the font's Widths array</description>
@@ -602,7 +602,7 @@
             </references>
         </rule>
         <rule object="PDSimpleFont">
-            <id specification="ISO_19005_1" clause="6.2.11.2" testNumber="6"/>
+            <id specification="ISO_19005_3" clause="6.2.11.2" testNumber="6"/>
             <description>All fonts and font programs used in a conforming file, regardless of rendering mode usage, shall conform to the provisions
 			in ISO 32000-1:2008, 9.6 and 9.7, as well as to the font specifications referenced by these provisions.
 			Widths - array - (Required except for the standard 14 fonts; indirect reference preferred) An array of (LastChar − FirstChar + 1) widths</description>
@@ -617,7 +617,7 @@
             </references>
         </rule>
         <rule object="PDType0Font">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.3" testNumber="1"/>
             <description>For any given composite (Type 0) font within a conforming file, the CIDSystemInfo entry in its CIDFont dictionary and its Encoding dictionary 
 			shall have the following relationship: 
 			- If the Encoding key in the Type 0 font dictionary is Identity-H or Identity-V, any values of Registry, Ordering, 
@@ -632,7 +632,7 @@
             <references/>
         </rule>
         <rule object="PDCIDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.11.3" testNumber="2"/>
             <description>ISO 32000-1:2008, 9.7.4, Table 117 requires that all embedded Type 2 CIDFonts in the CIDFont dictionary shall contain a 
 			CIDToGIDMap entry that shall be a stream mapping from CIDs to glyph indices or the name Identity, as described in ISO 32000-1:2008, 9.7.4, Table 117.</description>
             <test>Subtype != &quot;CIDFontType2&quot; || CIDToGIDMap != null</test>
@@ -645,7 +645,7 @@
             </references>
         </rule>
         <rule object="PDCMap">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.11.3" testNumber="3"/>
             <description>All CMaps used within a PDF/A-2 file, except those listed in ISO 32000-1:2008, 9.7.5.2, Table 118, shall be embedded in that file as described 
 			in ISO 32000-1:2008, 9.7.5.</description>
             <test>CMapName == &quot;Identity-H&quot; || CMapName == &quot;Identity-V&quot; || CMapName == &quot;GB-EUC-H&quot; || CMapName == &quot;GB-EUC-V&quot; ||
@@ -673,7 +673,7 @@
             </references>
         </rule>
         <rule object="CMapFile">
-            <id specification="ISO_19005_1" clause="6.2.11.3" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.11.3" testNumber="4"/>
             <description>For those CMaps that are embedded, the integer value of the WMode entry in the CMap dictionary shall be identical to the WMode value
 			in the embedded CMap stream.</description>
             <test>WMode == dictWMode</test>
@@ -684,7 +684,7 @@
             <references/>
         </rule>
         <rule object="PDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.4" testNumber="1"/>
             <description>The font programs for all fonts used for rendering within a conforming file shall be embedded within that file, as defined in ISO 32000-1:2008, 9.9.</description>
             <test>Subtype == &quot;Type3&quot; || Subtype == &quot;Type0&quot; || fontFile_size == 1</test>
             <error>
@@ -696,7 +696,7 @@
             </references>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.11.4" testNumber="2"/>
             <description>Embedded fonts shall define all glyphs referenced for rendering within the conforming file.</description>
             <test>isGlyphPresent == true</test>
             <error>
@@ -706,7 +706,7 @@
             <references/>
         </rule>
         <rule object="PDType1Font">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.11.4" testNumber="3"/>
             <description>If the FontDescriptor dictionary of an embedded Type 1 font contains a CharSet string, then it shall list the character names of all glyphs
 			present in the font program, regardless of whether a glyph in the font is referenced or used by the PDF or not.</description>
             <test>CharSet == null || charSetListsAllGlyphs == true</test>
@@ -717,7 +717,7 @@
             <references/>
         </rule>
         <rule object="PDCIDFont">
-            <id specification="ISO_19005_1" clause="6.2.11.4" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.11.4" testNumber="4"/>
             <description>If the FontDescriptor dictionary of an embedded CID font contains a CIDSet stream, then it shall identify all CIDs which are present in the font program,
 			regardless of whether a CID in the font is referenced or used by the PDF or not.</description>
             <test>CIDSet_size == 0 || cidSetListsAllGlyphs == true</test>
@@ -728,7 +728,7 @@
             <references/>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.5" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.5" testNumber="1"/>
             <description>For every font embedded in a conforming file and used for rendering, the glyph width information in the font dictionary and in the embedded 
 			font program shall be consistent.</description>
             <test>isWidthConsistent == true</test>
@@ -739,7 +739,7 @@
             <references/>
         </rule>
         <rule object="TrueTypeFontProgram">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.6" testNumber="1"/>
             <description>For all non-symbolic TrueType fonts used for rendering, the embedded TrueType font program shall contain one or several non-symbolic 
 			cmap entries such that all necessary glyph lookups can be carried out.</description>
             <test>isSymbolic == true || nrCmaps &gt;= 1</test>
@@ -750,7 +750,7 @@
             <references/>
         </rule>
         <rule object="PDTrueTypeFont">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.2.11.6" testNumber="2"/>
             <description>No non-symbolic TrueType font shall define a Differences array unless all of the glyph names in
 			the Differences array are listed in the Adobe Glyph List and the embedded font program contains at least the
 			Microsoft Unicode (3,1 – Platform ID=3, Encoding ID=1) encoding in the &quot;cmap&quot; table.</description>
@@ -763,7 +763,7 @@
             <references/>
         </rule>
         <rule object="PDTrueTypeFont">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.2.11.6" testNumber="3"/>
             <description>Symbolic TrueType fonts shall not contain an Encoding entry in the font dictionary</description>
             <test>isSymbolic == false || Encoding == null</test>
             <error>
@@ -773,7 +773,7 @@
             <references/>
         </rule>
         <rule object="TrueTypeFontProgram">
-            <id specification="ISO_19005_1" clause="6.2.11.6" testNumber="4"/>
+            <id specification="ISO_19005_3" clause="6.2.11.6" testNumber="4"/>
             <description>Symbolic TrueType fonts shall not contain an Encoding entry in the font dictionary, and the &quot;cmap&quot; table in the embedded font program
 			shall either contain exactly one encoding or it shall contain, at least, the Microsoft Symbol (3,0 – Platform ID=3, Encoding ID=0) encoding.</description>
             <test>isSymbolic == false || nrCmaps == 1 || cmap30Present == true</test>
@@ -784,7 +784,7 @@
             <references/>
         </rule>
         <rule object="Glyph">
-            <id specification="ISO_19005_1" clause="6.2.11.8" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.2.11.8" testNumber="1"/>
             <description>A PDF/A-2 compliant document shall not contain a reference to the .notdef glyph from any of the text showing
 			operators, regardless of text rendering mode, in any content stream.</description>
             <test>name != &quot;.notdef&quot;</test>
@@ -795,7 +795,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.1" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.3.1" testNumber="1"/>
             <description>Annotation types not defined in ISO 32000-1 shall not be permitted. Additionally, the 3D, Sound, Screen and Movie types shall not be permitted.</description>
             <test>Subtype == &quot;Text&quot; || Subtype == &quot;Link&quot; || Subtype == &quot;FreeText&quot; || Subtype == &quot;Line&quot; || 
 			Subtype == &quot;Square&quot; || Subtype == &quot;Circle&quot; || Subtype == &quot;Polygon&quot; || Subtype == &quot;PolyLine&quot; ||
@@ -812,7 +812,7 @@
             </references>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.3.2" testNumber="1"/>
             <description>Except for annotation dictionaries whose Subtype value is Popup, all annotation dictionaries shall contain the F key.</description>
             <test>Subtype == &quot;Popup&quot; || F != null</test>
             <error>
@@ -822,7 +822,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.3.2" testNumber="2"/>
             <description>If present, the F key's Print flag bit shall be set to 1 and its Hidden, Invisible, ToggleNoView, and NoView flag bits shall be set to 0.</description>
             <test>F == null || ((F &amp; 1) == 0 &amp;&amp; (F &amp; 2) == 0 &amp;&amp; (F &amp; 4) == 4 &amp;&amp; (F &amp; 32) == 0 &amp;&amp; (F &amp; 256) == 0)</test>
             <error>
@@ -832,7 +832,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.2" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.3.2" testNumber="3"/>
             <description>Text annotations should set the NoZoom and NoRotate flag bits of the F key to 1.</description>
             <test>Subtype != &quot;Text&quot; || (F != null &amp;&amp; (F &amp; 8) == 1 &amp;&amp; (F &amp; 16) == 1)</test>
             <error>
@@ -842,7 +842,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.3" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.3.3" testNumber="1"/>
             <description>Every annotation (including those whose Subtype value is Widget, as used for form fields), except for the two cases listed below,
 			shall have at least one appearance dictionary:
 			- annotations where the value of the Rect key consists of an array where value 1 is equal to value 3 and value 2 is equal to value 4;
@@ -855,7 +855,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.3.3" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.3.3" testNumber="2"/>
             <description>For all annotation dictionaries containing an AP key, the appearance dictionary that it defines as its value shall
 			contain only the N key. If an annotation dictionary's Subtype key has a value of Widget and its FT key has a
 			value of Btn, the value of the N key shall be an appearance subdictionary, otherwise the value of the N key shall be an appearance stream.</description>
@@ -867,7 +867,7 @@
             <references/>
         </rule>
         <rule object="PDAnnot">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.4.1" testNumber="1"/>
             <description>A Widget annotation dictionary or Field dictionary shall not contain the A or AA keys.</description>
             <test>Subtype != &quot;Widget&quot; || (A_size == 0 &amp;&amp; AA_size == 0)</test>
             <error>
@@ -877,7 +877,7 @@
             <references/>
         </rule>
         <rule object="PDFormField">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.4.1" testNumber="2"/>
             <description>A Widget annotation dictionary or Field dictionary shall not contain the A or AA keys.</description>
             <test>AA_size == 0</test>
             <error>
@@ -887,7 +887,7 @@
             <references/>
         </rule>
         <rule object="PDAcroForm">
-            <id specification="ISO_19005_1" clause="6.4.1" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.4.1" testNumber="3"/>
             <description>The NeedAppearances flag of the interactive form dictionary shall either not be present or shall be false.</description>
             <test>NeedAppearances == null || NeedAppearances == false</test>
             <error>
@@ -897,7 +897,7 @@
             <references/>
         </rule>
         <rule object="PDAcroForm">
-            <id specification="ISO_19005_1" clause="6.4.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.4.2" testNumber="1"/>
             <description>The document's interactive form dictionary that forms the value of the AcroForm key in the document's Catalog of a PDF/A-2 file, 
 			if present, shall not contain the XFA key.</description>
             <test>XFA_size == 0</test>
@@ -908,7 +908,7 @@
             <references/>
         </rule>
         <rule object="CosDocument">
-            <id specification="ISO_19005_1" clause="6.4.2" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.4.2" testNumber="2"/>
             <description>A document's Catalog shall not contain the NeedsRendering key.</description>
             <test>NeedsRendering == false</test>
             <error>
@@ -918,7 +918,7 @@
             <references/>
         </rule>
         <rule object="PDAction">
-            <id specification="ISO_19005_1" clause="6.5.1" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.5.1" testNumber="1"/>
             <description>The Launch, Sound, Movie, ResetForm, ImportData, Hide, SetOCGState, Rendition, Trans, GoTo3DView and JavaScript actions shall not be permitted. 
 			Additionally, the deprecated set-state and noop actions shall not be permitted.</description>
             <test>S == &quot;GoTo&quot; || S == &quot;GoToR&quot; || S == &quot;GotToE&quot; || S == &quot;Thread&quot; || S == &quot;URI&quot; || S == &quot;Named&quot; || S == &quot;SubmitForm&quot;</test>
@@ -931,7 +931,7 @@
             </references>
         </rule>
         <rule object="PDNamedAction">
-            <id specification="ISO_19005_1" clause="6.5.1" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.5.1" testNumber="2"/>
             <description>Named actions other than NextPage, PrevPage, FirstPage, and LastPage shall not be permitted.</description>
             <test>N == &quot;NextPage&quot; || N == &quot;PrevPage&quot; || N == &quot;FirstPage&quot; || N == &quot;LastPage&quot;</test>
             <error>
@@ -943,7 +943,7 @@
             </references>
         </rule>
         <rule object="PDDocument">
-            <id specification="ISO_19005_1" clause="6.5.2" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.5.2" testNumber="1"/>
             <description>The document's Catalog shall not include an AA entry for an additional-actions dictionary.</description>
             <test>AA_size == 0</test>
             <error>
@@ -953,7 +953,7 @@
             <references/>
         </rule>
         <rule object="PDPage">
-            <id specification="ISO_19005_1" clause="6.5.2" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.5.2" testNumber="2"/>
             <description>The Page dictionary shall not include an AA entry for an additional-actions dictionary.</description>
             <test>AA_size == 0</test>
             <error>
@@ -963,7 +963,7 @@
             <references/>
         </rule>
         <rule object="PDFAIdSchema">
-            <id specification="ISO_19005_1" clause="6.6.4" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.6.4" testNumber="2"/>
             <description>The value of pdfaid:part shall be the part number of ISO 19005 to which the file conforms. Files prepared in
  			compliance with this part of ISO 19005 shall use a value of 3.</description>
             <test>part == 3</test>
@@ -976,7 +976,7 @@
             <references/>
         </rule>
         <rule object="PDFAIdSchema">
-            <id specification="ISO_19005_1" clause="6.6.4" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.6.4" testNumber="3"/>
             <description>Level B conforming file shall specify the value of pdfaid:conformance as B.</description>
             <test>conformance == &quot;B&quot;</test>
             <error>
@@ -988,7 +988,7 @@
             <references/>
         </rule>
         <rule object="EmbeddedFile">
-            <id specification="ISO_19005_1" clause="6.8" testNumber="1"/>
+            <id specification="ISO_19005_3" clause="6.8" testNumber="1"/>
             <description>The MIME type of an embedded file, or a subset of a file, shall be specified using the Subtype key of the file specification dictionary.
 			If the MIME type is not known, the &quot;application/octet-stream&quot; shall be used.</description>
             <test>Subtype != null</test>
@@ -999,7 +999,7 @@
             <references/>
         </rule>
         <rule object="CosFileSpecification">
-            <id specification="ISO_19005_1" clause="6.8" testNumber="2"/>
+            <id specification="ISO_19005_3" clause="6.8" testNumber="2"/>
             <description>The file specification dictionary for an embedded file shall contain the F and UF keys</description>
             <test>EF_size == 0 || (F != null &amp;&amp; UF != null)</test>
             <error>
@@ -1009,7 +1009,7 @@
             <references/>
         </rule>
         <rule object="CosFileSpecification">
-            <id specification="ISO_19005_1" clause="6.8" testNumber="3"/>
+            <id specification="ISO_19005_3" clause="6.8" testNumber="3"/>
             <description>In order to enable identification of the relationship between the file specification dictionary and the content that is referring to it,
 			a new (required) key has been defined and its presence (in the dictionary) is required.</description>
             <test>AFRelationship != null</test>

--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCliProcessor.java
@@ -25,10 +25,10 @@ import org.verapdf.model.ModelParser;
 import org.verapdf.pdfa.PDFAValidator;
 import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.results.ValidationResult;
-import org.verapdf.pdfa.results.ValidationResults;
 import org.verapdf.pdfa.validation.Profiles;
 import org.verapdf.pdfa.validation.ValidationProfile;
 import org.verapdf.pdfa.validators.Validators;
+import org.verapdf.report.CliReport;
 import org.verapdf.report.FeaturesReport;
 import org.verapdf.report.HTMLReport;
 import org.verapdf.report.ItemDetails;
@@ -133,8 +133,15 @@ final class VeraPdfCliProcessor {
                     + item.getName());
             e.printStackTrace();
         }
-        if (this.format == FormatOption.XML)
-            outputXmlResults(item, validationResult, featuresCollection);
+        if (this.format == FormatOption.XML) {
+            CliReport report = CliReport.fromValues(item, validationResult, FeaturesReport.fromValues(featuresCollection));
+            try {
+                CliReport.toXml(report, System.out, Boolean.TRUE);
+            } catch (JAXBException excep) {
+                // TODO Auto-generated catch block
+                excep.printStackTrace();
+            }
+        }
         else if (this.format == FormatOption.TEXT) {
             System.out.println(item.getName() + ":"
                     + validationResult.isCompliant());
@@ -146,25 +153,6 @@ final class VeraPdfCliProcessor {
                     this.logPassed, null, featuresCollection,
                     System.currentTimeMillis() - start);
             outputMrr(report, this.format == FormatOption.HTML);
-        }
-    }
-
-    private static void outputXmlResults(final ItemDetails item,
-            final ValidationResult validationResult,
-            final FeaturesCollection featuresCollection) {
-        try {
-            ItemDetails.toXml(item, System.out, Boolean.TRUE);
-            if (validationResult != null)
-                ValidationResults.toXml(validationResult, System.out,
-                        Boolean.TRUE);
-            if (featuresCollection != null) {
-                FeaturesReport featuresReport = FeaturesReport
-                        .fromValues(featuresCollection);
-                FeaturesReport.toXml(featuresReport, System.out, Boolean.TRUE);
-            }
-        } catch (JAXBException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
     }
 

--- a/gui/src/main/java/org/verapdf/report/CliReport.java
+++ b/gui/src/main/java/org/verapdf/report/CliReport.java
@@ -1,0 +1,66 @@
+/**
+ * 
+ */
+package org.verapdf.report;
+
+import java.io.OutputStream;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.verapdf.pdfa.results.ValidationResult;
+import org.verapdf.pdfa.results.ValidationResults;
+
+/**
+ * @author cfw
+ *
+ */
+@XmlRootElement(name = "cliReport")
+public final class CliReport {
+    @XmlElement
+    private final ItemDetails itemDetails;
+    @XmlElement
+    private final ValidationResult validationResult;
+    @XmlElement
+    private final FeaturesReport featuresReport;
+
+    private CliReport() {
+        this(ItemDetails.DEFAULT, ValidationResults.defaultResult(), null);
+    }
+
+    private CliReport(final ItemDetails itemDetails, final ValidationResult result,
+            final FeaturesReport featuresReport) {
+        this.itemDetails = itemDetails;
+        this.validationResult = result;
+        this.featuresReport = featuresReport;
+    }
+
+    public static CliReport fromValues(ItemDetails details, ValidationResult result,
+            FeaturesReport features) {
+        return new CliReport(details, result, features);
+    }
+
+    /**
+     * @param toConvert
+     * @param stream
+     * @param prettyXml
+     * @throws JAXBException
+     */
+    public static void toXml(final CliReport toConvert,
+            final OutputStream stream, Boolean prettyXml) throws JAXBException {
+        Marshaller varMarshaller = getMarshaller(prettyXml);
+        varMarshaller.marshal(toConvert, stream);
+    }
+
+    private static Marshaller getMarshaller(Boolean setPretty)
+            throws JAXBException {
+        JAXBContext context = JAXBContext
+                .newInstance(CliReport.class);
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, setPretty);
+        return marshaller;
+    }
+}

--- a/gui/src/main/java/org/verapdf/report/package-info.java
+++ b/gui/src/main/java/org/verapdf/report/package-info.java
@@ -12,7 +12,7 @@
  * @version 0.7
  * @since 0.7
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/ValidationProfile", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/ValidationProfile")}, elementFormDefault = XmlNsForm.QUALIFIED)
 package org.verapdf.report;
 
 import javax.xml.bind.annotation.XmlNs;

--- a/gui/src/main/java/org/verapdf/report/package-info.java
+++ b/gui/src/main/java/org/verapdf/report/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Interfaces and reference implementations encapsulating the results of PDF/A
+ * validation.
+ * <p>
+ * See the static {@link org.verapdf.pdfa.results.ValidationResults} utility
+ * class for helper methods that create the different Result types. All of the
+ * reference implementations for the types are JAXB annotated. There are helper
+ * methods for serialisation and de-serialisation to and from XML.
+ * </p>
+ *
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ * @version 0.7
+ * @since 0.7
+ */
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://www.verapdf.org/Validation", xmlns = {@XmlNs(prefix = "", namespaceURI = "http://www.verapdf.org/Validation")}, elementFormDefault = XmlNsForm.QUALIFIED)
+package org.verapdf.report;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+


### PR DESCRIPTION
Updates and minor fixes:

 - up to date validation profiles now in the core resources;
 - namespace consistency across entities (may need reviewing);
 - all logging output to stderr, fixes #430; and
 - single XML document for CLI output, fixes #411.