### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/gui/src/main/java/org/verapdf/gui/CheckerPanel.java
+++ b/gui/src/main/java/org/verapdf/gui/CheckerPanel.java
@@ -375,6 +375,8 @@ class CheckerPanel extends JPanel {
 					case 2:
 						CheckerPanel.this.fixMetadata.setEnabled(false);
 						break;
+					default:
+						break;
 				}
 			}
 		});

--- a/gui/src/main/java/org/verapdf/report/MetadataFixesReport.java
+++ b/gui/src/main/java/org/verapdf/report/MetadataFixesReport.java
@@ -50,6 +50,8 @@ public class MetadataFixesReport {
             case FIX_ERROR:
                 errorMessages = new ArrayList<>(appliedFixes);
                 break;
+            default:
+				break;
         }
         String status = repairStatus.toString();
         return new MetadataFixesReport(status, completedFixes, fixes, errorMessages);

--- a/metadata-fixer/src/main/java/org/verapdf/metadata/fixer/utils/parser/XMLProcessedObjectsParser.java
+++ b/metadata-fixer/src/main/java/org/verapdf/metadata/fixer/utils/parser/XMLProcessedObjectsParser.java
@@ -104,6 +104,8 @@ public class XMLProcessedObjectsParser implements ProcessedObjectsParser {
 				case TEST_TAG:
 					test = children.getTextContent();
 					break;
+				default:
+					break;
 			}
 		}
 

--- a/model-implementation/src/main/java/org/verapdf/model/tools/xmp/SchemasDefinitionCreator.java
+++ b/model-implementation/src/main/java/org/verapdf/model/tools/xmp/SchemasDefinitionCreator.java
@@ -107,6 +107,8 @@ public class SchemasDefinitionCreator {
                     case "namespaceURI":
                         namespaceURI = child.getValue();
                         break;
+                    default:
+                    	break;
                 }
             }
         }
@@ -135,6 +137,8 @@ public class SchemasDefinitionCreator {
                     case "valueType":
                         valueType = child.getValue();
                         break;
+                    default:
+                    	break;
                 }
             }
         }

--- a/model-implementation/src/main/java/org/verapdf/model/tools/xmp/ValidatorsContainerCreator.java
+++ b/model-implementation/src/main/java/org/verapdf/model/tools/xmp/ValidatorsContainerCreator.java
@@ -182,6 +182,8 @@ public class ValidatorsContainerCreator {
                             fields = getStructureMapFromFieldsNode(child);
                         }
                         break;
+                    default:
+                    	break;
                 }
             }
         }
@@ -208,6 +210,8 @@ public class ValidatorsContainerCreator {
                         case "valueType":
                             valueType = child.getValue();
                             break;
+                        default:
+                        	break;
                     }
                 }
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.
Sameer Misger