### PR TITLE
Fixing squid:UselessParenthesesCheck-Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/core/src/main/java/org/verapdf/pdfa/validators/BaseValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validators/BaseValidator.java
@@ -346,7 +346,7 @@ class BaseValidator implements PDFAValidator {
                 locationContext);
         TestAssertion assertion = ValidationResults.assertionFromValues(this.testCounter, rule
                 .getRuleId(),
-                (assertionResult) ? Status.PASSED : Status.FAILED, rule
+                assertionResult ? Status.PASSED : Status.FAILED, rule
                         .getDescription(), location);
         if (this.isCompliant)
             this.isCompliant = assertionResult;

--- a/feature-report/src/main/java/org/verapdf/features/FeaturesPluginsLoader.java
+++ b/feature-report/src/main/java/org/verapdf/features/FeaturesPluginsLoader.java
@@ -99,7 +99,7 @@ public class FeaturesPluginsLoader {
 		JarInputStream jarStream = new JarInputStream(new FileInputStream(jar));
 		JarEntry jarEntry = jarStream.getNextJarEntry();
 		while (jarEntry != null) {
-			if ((jarEntry.getName().endsWith(".class"))) {
+			if (jarEntry.getName().endsWith(".class")) {
 				String className = jarEntry.getName().replaceAll("/", ".");
 				String myClass = className.substring(0, className.lastIndexOf('.'));
 				classNames.add(myClass);

--- a/gui/src/main/java/org/verapdf/report/ValidationReport.java
+++ b/gui/src/main/java/org/verapdf/report/ValidationReport.java
@@ -63,6 +63,6 @@ public class ValidationReport {
     }
 
     private static String getStatement(boolean status) {
-        return (status) ? COMPLIANT_STATEMENT : NONCOMPLIANT_STATEMENT;
+        return status ? COMPLIANT_STATEMENT : NONCOMPLIANT_STATEMENT;
     }
 }

--- a/model-implementation/src/main/java/org/verapdf/model/impl/axl/AXLExtensionSchemasContainer.java
+++ b/model-implementation/src/main/java/org/verapdf/model/impl/axl/AXLExtensionSchemasContainer.java
@@ -56,7 +56,7 @@ public class AXLExtensionSchemasContainer extends AXLXMPObject implements Extens
     @Override
     public Boolean getisValidBag() {
         PropertyOptions options = this.xmpNode.getOptions();
-        return (options.isArray() && !(options.isArrayOrdered() || options.isArrayAlternate()));
+        return options.isArray() && !(options.isArrayOrdered() || options.isArrayAlternate());
     }
 
     @Override

--- a/model-implementation/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDStructElem.java
+++ b/model-implementation/src/main/java/org/verapdf/model/impl/pb/pd/PBoxPDStructElem.java
@@ -69,7 +69,7 @@ public class PBoxPDStructElem extends PBoxPDObject implements PDStructElem {
 	}
 
 	private List<PDStructElem> getChildren() {
-		return TaggedPDFHelper.getChildren(((COSDictionary) this.simplePDObject), LOGGER);
+		return TaggedPDFHelper.getChildren((COSDictionary) this.simplePDObject, LOGGER);
 	}
 
 	private List<CosUnicodeName> getStructureType() {

--- a/model-implementation/src/main/java/org/verapdf/model/impl/pb/pd/font/PBoxPDCIDFont.java
+++ b/model-implementation/src/main/java/org/verapdf/model/impl/pb/pd/font/PBoxPDCIDFont.java
@@ -65,7 +65,7 @@ public class PBoxPDCIDFont extends PBoxPDFont implements PDCIDFont {
                 //reverse bit order in bit set (convert to big endian)
                 BitSet bitSet = toBitSetBigEndian(cidSetBytes);
 
-                org.apache.pdfbox.pdmodel.font.PDCIDFont cidFont = ((org.apache.pdfbox.pdmodel.font.PDCIDFont) this.pdFontLike);
+                org.apache.pdfbox.pdmodel.font.PDCIDFont cidFont = (org.apache.pdfbox.pdmodel.font.PDCIDFont) this.pdFontLike;
                 for (int i = 1; i < bitSet.size(); i++) {
                     if (bitSet.get(i) && !cidFont.hasGlyph(i)) {
                         return Boolean.FALSE;
@@ -119,7 +119,7 @@ public class PBoxPDCIDFont extends PBoxPDFont implements PDCIDFont {
         for(int j = 0; j < source.length; j++) {
             int b = source[j] >= 0 ? source[j] : 256 + source[j];
             for(int k = 0; k < 8; k++) {
-                bitSet.set(i++, ((b & 0x80) != 0));
+                bitSet.set(i++, (b & 0x80) != 0);
                 b = b << 1;
             }
         }

--- a/model-implementation/src/main/java/org/verapdf/model/tools/TaggedPDFHelper.java
+++ b/model-implementation/src/main/java/org/verapdf/model/tools/TaggedPDFHelper.java
@@ -41,7 +41,7 @@ public class TaggedPDFHelper {
 			list.add(new PBoxPDStructElem((COSDictionary) children));
 			return Collections.unmodifiableList(list);
 		} else if (children instanceof COSArray) {
-			return getChildrenFromArray(((COSArray) children), logger);
+			return getChildrenFromArray((COSArray) children, logger);
 		} else {
 			logger.warn("Children type of Structure Tree Root or Structure Element " +
 					"must be 'COSDictionary' or 'COSArray' but got: "

--- a/model-implementation/src/main/java/org/verapdf/model/tools/xmp/validators/ArrayTypeValidator.java
+++ b/model-implementation/src/main/java/org/verapdf/model/tools/xmp/validators/ArrayTypeValidator.java
@@ -42,10 +42,10 @@ public class ArrayTypeValidator {
                 isValidArrayType = options.isArrayAlternate();
                 break;
             case SEQ:
-                isValidArrayType = (options.isArrayOrdered() && !options.isArrayAlternate());
+                isValidArrayType = options.isArrayOrdered() && !options.isArrayAlternate();
                 break;
             case BAG:
-                isValidArrayType = (options.isArray() && !(options.isArrayOrdered() || options.isArrayAlternate()));
+                isValidArrayType = options.isArray() && !(options.isArrayOrdered() || options.isArrayAlternate());
                 break;
             default:
                 throw new IllegalStateException("Array type validator must be created with valid type");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule " UselessParenthesesCheck -     Useless parentheses around expressions should be removed to prevent any misunderstanding". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck


Please let me know if you have any questions.
Sameer Misger