### PR TITLE
Fixed greedy processing of stdin.

### DIFF
--- a/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
+++ b/gui/src/main/java/org/verapdf/cli/VeraPdfCli.java
@@ -58,14 +58,15 @@ public final class VeraPdfCli {
         }
 
         messagesFromParser(cliArgParser);
-
-        try {
-            VeraPdfCliProcessor processor = VeraPdfCliProcessor
-                    .createProcessorFromArgs(cliArgParser);
-            processor.processPaths(cliArgParser.getPdfPaths());
-        } catch (IOException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+        if (isProcess(cliArgParser)) {
+            try {
+                VeraPdfCliProcessor processor = VeraPdfCliProcessor
+                        .createProcessorFromArgs(cliArgParser);
+                processor.processPaths(cliArgParser.getPdfPaths());
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
         }
     }
 
@@ -94,5 +95,14 @@ public final class VeraPdfCli {
         System.out.println("Built: " + RELEASE_DETAILS.getBuildDate());
         System.out.println(RELEASE_DETAILS.getRights());
         System.out.println();
+    }
+
+    private static boolean isProcess(final VeraCliArgParser parser) {
+        if (parser.getPdfPaths().isEmpty()
+                && (parser.isHelp() || parser.listProfiles() || parser
+                        .showVersion())) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
STDIN processing no longer triggered if any of the following commands are present and the file list is empty:

    verapdf --version
    verapdf -h
    verapdf --help
    verapdf -l
    verapdf --list

