### PR TITLE
REFACT - Streaming Processor

### DIFF
--- a/core/src/main/java/org/verapdf/ReleaseDetails.java
+++ b/core/src/main/java/org/verapdf/ReleaseDetails.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,241 +35,232 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "releaseDetails")
 public final class ReleaseDetails {
 	private static final Logger LOGGER = Logger.getLogger(ReleaseDetails.class.getCanonicalName());
-    public static final String APPLICATION_PROPERTIES_ROOT = "org/verapdf/release/";
-    public static final String PROPERTIES_EXT = "properties";
-    public static final String LIBRARY_DETAILS_RESOURCE = APPLICATION_PROPERTIES_ROOT
-            + "library." + PROPERTIES_EXT;
+	public static final String APPLICATION_PROPERTIES_ROOT = "org/verapdf/release/";
+	public static final String PROPERTIES_EXT = "properties";
+	public static final String LIBRARY_DETAILS_RESOURCE = APPLICATION_PROPERTIES_ROOT + "library." + PROPERTIES_EXT;
 
-    private static final String RAW_DATE_FORMAT = "${maven.build.timestamp.format}";
-    private static final String RIGHTS = "Developed and released by the veraPDF Consortium.\n"
-            + "Funded by the PREFORMA project.\n"
-            + "Released under the GNU General Public License v3\n"
-            + "and the Mozilla Public License v2 or later.\n";
+	private static final String RAW_DATE_FORMAT = "${maven.build.timestamp.format}";
+	private static final String RIGHTS = "Developed and released by the veraPDF Consortium.\n"
+			+ "Funded by the PREFORMA project.\n" + "Released under the GNU General Public License v3\n"
+			+ "and the Mozilla Public License v2 or later.\n";
 
-    private static final ReleaseDetails DEFAULT = new ReleaseDetails();
-    private static final Map<String, ReleaseDetails> DETAILS = new HashMap<>();
-    static {
-        ReleaseDetails details = fromResource(LIBRARY_DETAILS_RESOURCE);
-        DETAILS.put(details.id, details);
-    }
+	private static final ReleaseDetails DEFAULT = new ReleaseDetails();
+	private static final Map<String, ReleaseDetails> DETAILS = new HashMap<>();
+	static {
+		ReleaseDetails details = fromResource(LIBRARY_DETAILS_RESOURCE);
+		DETAILS.put(details.id, details);
+	}
 
-    @XmlAttribute
-    private final String id;
-    @XmlAttribute
-    private final String version;
-    @XmlAttribute
-    private final Date buildDate;
-    @XmlElement
-    private final String rights = RIGHTS;
+	@XmlAttribute
+	private final String id;
+	@XmlAttribute
+	private final String version;
+	@XmlAttribute
+	private final Date buildDate;
+	@XmlElement
+	private final String rights = RIGHTS;
 
-    private ReleaseDetails() {
-        this("name", "version", new Date());
-    }
+	private ReleaseDetails() {
+		this("name", "version", new Date());
+	}
 
-    private ReleaseDetails(final String id, final String version,
-            final Date buildDate) {
-        this.id = id;
-        this.version = version;
-        this.buildDate = new Date(buildDate.getTime());
-    }
+	private ReleaseDetails(final String id, final String version, final Date buildDate) {
+		this.id = id;
+		this.version = version;
+		this.buildDate = new Date(buildDate.getTime());
+	}
 
-    /**
-     * @return the id of the release artifact
-     */
-    public String getId() {
-        return this.id;
-    }
+	/**
+	 * @return the id of the release artifact
+	 */
+	public String getId() {
+		return this.id;
+	}
 
-    /**
-     * @return the veraPDF library version number
-     */
-    public String getVersion() {
-        return this.version;
-    }
+	/**
+	 * @return the veraPDF library version number
+	 */
+	public String getVersion() {
+		return this.version;
+	}
 
-    /**
-     * @return the veraPDF library build date
-     */
-    public Date getBuildDate() {
-        return new Date(this.buildDate.getTime());
-    }
+	/**
+	 * @return the veraPDF library build date
+	 */
+	public Date getBuildDate() {
+		return new Date(this.buildDate.getTime());
+	}
 
-    /**
-     * @return the veraPDF library rights statement
-     */
-    public String getRights() {
-        return this.rights;
-    }
+	/**
+	 * @return the veraPDF library rights statement
+	 */
+	public String getRights() {
+		return this.rights;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
-        result = prime * result
-                + ((this.buildDate == null) ? 0 : this.buildDate.hashCode());
-        result = prime * result
-                + ((this.version == null) ? 0 : this.version.hashCode());
-        return result;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
+		result = prime * result + ((this.buildDate == null) ? 0 : this.buildDate.hashCode());
+		result = prime * result + ((this.version == null) ? 0 : this.version.hashCode());
+		return result;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReleaseDetails other = (ReleaseDetails) obj;
-        if (this.buildDate == null) {
-            if (other.buildDate != null)
-                return false;
-        } else if (!this.buildDate.equals(other.buildDate))
-            return false;
-        if (this.id == null) {
-            if (other.id != null)
-                return false;
-        } else if (!this.id.equals(other.id))
-            return false;
-        if (this.version == null) {
-            if (other.version != null)
-                return false;
-        } else if (!this.version.equals(other.version))
-            return false;
-        return true;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ReleaseDetails other = (ReleaseDetails) obj;
+		if (this.buildDate == null) {
+			if (other.buildDate != null)
+				return false;
+		} else if (!this.buildDate.equals(other.buildDate))
+			return false;
+		if (this.id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!this.id.equals(other.id))
+			return false;
+		if (this.version == null) {
+			if (other.version != null)
+				return false;
+		} else if (!this.version.equals(other.version))
+			return false;
+		return true;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public String toString() {
-        return "ReleaseDetails [id=" + this.id + ", version=" + this.version
-                + ", buildDate=" + this.buildDate + "]";
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public String toString() {
+		return "ReleaseDetails [id=" + this.id + ", version=" + this.version + ", buildDate=" + this.buildDate + "]";
+	}
 
-    public static ReleaseDetails defaultInstance() {
-        return DEFAULT;
-    }
+	public static ReleaseDetails defaultInstance() {
+		return DEFAULT;
+	}
 
-    /**
-     * @return the static immutable ReleaseDetails instance
-     */
-    public static ReleaseDetails getInstance() {
-        if (DETAILS.isEmpty()) {
-            return defaultInstance();
-        }
-        return DETAILS.values().toArray(new ReleaseDetails[DETAILS.size()])[0];
-    }
+	/**
+	 * @return the static immutable ReleaseDetails instance
+	 */
+	public static ReleaseDetails getInstance() {
+		if (DETAILS.isEmpty()) {
+			return defaultInstance();
+		}
+		return DETAILS.values().toArray(new ReleaseDetails[DETAILS.size()])[0];
+	}
 
-    /**
-     * @return the Set of ReleaseDetails ids as Strings
-     */
-    public static Set<String> getIds() {
-        return DETAILS.keySet();
-    }
+	/**
+	 * @return the Set of ReleaseDetails ids as Strings
+	 */
+	public static Set<String> getIds() {
+		return DETAILS.keySet();
+	}
 
-    /**
-     * Retrieve ReleaseDetails by id
-     * 
-     * @param id
-     *            the id to lookup
-     * @return the
-     */
-    public static ReleaseDetails byId(final String id) {
-        if (DETAILS.containsKey(id)) {
-            return DETAILS.get(id);
-        }
-        return defaultInstance();
-    }
+	/**
+	 * Retrieve ReleaseDetails by id
+	 * 
+	 * @param id
+	 *            the id to lookup
+	 * @return the
+	 */
+	public static ReleaseDetails byId(final String id) {
+		if (DETAILS.containsKey(id)) {
+			return DETAILS.get(id);
+		}
+		return defaultInstance();
+	}
 
-    /**
-     * Will load a ReleaseDetails instance from the resource found with
-     * resourceName. This should be a properties file with the appropriate
-     * release details properties.
-     * 
-     * @param resourceName
-     *            the name of the resource to load
-     */
-    public static ReleaseDetails addDetailsFromResource(final String resourceName) {
-        ReleaseDetails details = fromResource(resourceName);
-        DETAILS.put(details.id, details);
-        return details;
-    }
+	public static Collection<ReleaseDetails> getDetails() {
+		return DETAILS.values();
+	}
 
-    static void toXml(final ReleaseDetails toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-        Marshaller varMarshaller = getMarshaller(prettyXml);
-        varMarshaller.marshal(toConvert, stream);
-    }
+	/**
+	 * Will load a ReleaseDetails instance from the resource found with
+	 * resourceName. This should be a properties file with the appropriate
+	 * release details properties.
+	 * 
+	 * @param resourceName
+	 *            the name of the resource to load
+	 */
+	public static ReleaseDetails addDetailsFromResource(final String resourceName) {
+		ReleaseDetails details = fromResource(resourceName);
+		DETAILS.put(details.id, details);
+		return details;
+	}
 
-    static ReleaseDetails fromXml(final InputStream toConvert)
-            throws JAXBException {
-        Unmarshaller stringUnmarshaller = getUnmarshaller();
-        return (ReleaseDetails) stringUnmarshaller.unmarshal(toConvert);
-    }
+	static void toXml(final ReleaseDetails toConvert, final OutputStream stream, Boolean prettyXml)
+			throws JAXBException {
+		Marshaller varMarshaller = getMarshaller(prettyXml);
+		varMarshaller.marshal(toConvert, stream);
+	}
 
-    private static ReleaseDetails fromResource(final String resourceName) {
-        try (InputStream is = ReleaseDetails.class.getClassLoader()
-                .getResourceAsStream(resourceName)) {
-            if (is == null) {
-                return DEFAULT;
-            }
-            return fromPropertiesStream(is);
-        } catch (IOException excep) {
-            throw new IllegalStateException(
-                    "Couldn't load ReleaseDetails resource:" + resourceName,
-                    excep);
-        }
-    }
+	static ReleaseDetails fromXml(final InputStream toConvert) throws JAXBException {
+		Unmarshaller stringUnmarshaller = getUnmarshaller();
+		return (ReleaseDetails) stringUnmarshaller.unmarshal(toConvert);
+	}
 
-    private static ReleaseDetails fromPropertiesStream(final InputStream is)
-            throws IOException {
-        Properties props = new Properties();
-        props.load(is);
-        return fromProperties(props);
-    }
+	private static ReleaseDetails fromResource(final String resourceName) {
+		try (InputStream is = ReleaseDetails.class.getClassLoader().getResourceAsStream(resourceName)) {
+			if (is == null) {
+				return DEFAULT;
+			}
+			return fromPropertiesStream(is);
+		} catch (IOException excep) {
+			throw new IllegalStateException("Couldn't load ReleaseDetails resource:" + resourceName, excep);
+		}
+	}
 
-    private static ReleaseDetails fromProperties(final Properties props) {
-        String release = props.getProperty("verapdf.release.version");
-        String dateFormat = props.getProperty("verapdf.date.format");
-        String id = props.getProperty("verapdf.project.id");
-        Date date = new Date();
-        if (!dateFormat.equals(RAW_DATE_FORMAT)) {
-            SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
-            try {
-                date = formatter.parse(props
-                        .getProperty("verapdf.release.date"));
-            } catch (@SuppressWarnings("unused") ParseException e) {
-                /**
-                 * Safe to ignore this exception as release simply set to new
-                 * date.
-                 */
-            	LOGGER.log(Level.FINEST, "No parsable release date found, setting release date to:" + date, e);
-            }
-        }
-        return new ReleaseDetails(id, release, date);
-    }
+	private static ReleaseDetails fromPropertiesStream(final InputStream is) throws IOException {
+		Properties props = new Properties();
+		props.load(is);
+		return fromProperties(props);
+	}
 
-    private static Unmarshaller getUnmarshaller() throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(ReleaseDetails.class);
-        Unmarshaller unmarshaller = context.createUnmarshaller();
-        return unmarshaller;
-    }
+	private static ReleaseDetails fromProperties(final Properties props) {
+		String release = props.getProperty("verapdf.release.version");
+		String dateFormat = props.getProperty("verapdf.date.format");
+		String id = props.getProperty("verapdf.project.id");
+		Date date = new Date();
+		if (!dateFormat.equals(RAW_DATE_FORMAT)) {
+			SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
+			try {
+				date = formatter.parse(props.getProperty("verapdf.release.date"));
+			} catch (@SuppressWarnings("unused") ParseException e) {
+				/**
+				 * Safe to ignore this exception as release simply set to new
+				 * date.
+				 */
+				LOGGER.log(Level.FINEST, "No parsable release date found, setting release date to:" + date, e);
+			}
+		}
+		return new ReleaseDetails(id, release, date);
+	}
 
-    private static Marshaller getMarshaller(Boolean setPretty)
-            throws JAXBException {
-        JAXBContext context = JAXBContext.newInstance(ReleaseDetails.class);
-        Marshaller marshaller = context.createMarshaller();
-        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, setPretty);
-        return marshaller;
-    }
+	private static Unmarshaller getUnmarshaller() throws JAXBException {
+		JAXBContext context = JAXBContext.newInstance(ReleaseDetails.class);
+		Unmarshaller unmarshaller = context.createUnmarshaller();
+		return unmarshaller;
+	}
+
+	private static Marshaller getMarshaller(Boolean setPretty) throws JAXBException {
+		JAXBContext context = JAXBContext.newInstance(ReleaseDetails.class);
+		Marshaller marshaller = context.createMarshaller();
+		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, setPretty);
+		return marshaller;
+	}
 
 }

--- a/core/src/main/java/org/verapdf/core/JAXBCollection.java
+++ b/core/src/main/java/org/verapdf/core/JAXBCollection.java
@@ -1,0 +1,66 @@
+package org.verapdf.core;
+
+/*
+ * Copyright (c) 2013, Arno Moonen <info@arnom.nl>
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAnyElement;
+
+/**
+ * Generic collection wrapper class.
+ *
+ * Makes it easier to (un)marshall a collectiono of a single type.
+ *
+ * @author Arno Moonen <info@arnom.nl>
+ */
+public class JAXBCollection<T>
+{
+    @XmlAnyElement (lax = true)
+    private List<T> items;
+
+    public JAXBCollection(Collection<T> contents)
+    {
+        if (contents instanceof List)
+        {
+            this.items = (List<T>) contents;
+        }
+        else
+        {
+            this.items = new ArrayList<>(contents);
+        }
+
+    }
+
+    public JAXBCollection()
+    {
+        this(new ArrayList<T>());
+    }
+
+    public List<T> getItems()
+    {
+        return this.items;
+    }
+
+}

--- a/core/src/main/java/org/verapdf/core/XmlSerialiser.java
+++ b/core/src/main/java/org/verapdf/core/XmlSerialiser.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2013, Arno Moonen <info@arnom.nl>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.verapdf.core;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.SchemaOutputResolver;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLStreamWriter;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+
+public final class XmlSerialiser {
+	private static final String NOID = "no-id"; //$NON-NLS-1$
+
+	private XmlSerialiser() {
+
+	}
+
+	/**
+	 * Convert a string to an object of a given class.
+	 *
+	 * @param clz
+	 *            Type of object
+	 * @param source
+	 *            Input string
+	 * @return Object of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> T typeFromXml(Class<T> clz, String source) throws JAXBException {
+		return typeFromXml(clz, new StringReader(source));
+	}
+
+	/**
+	 * Convert the contents of a file to an object of a given class.
+	 *
+	 * @param clz
+	 *            Type of object
+	 * @param source
+	 *            File to be read
+	 * @return Object of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> T typeFromXml(Class<T> clz, File source) throws JAXBException {
+		return typeFromXml(clz, new StreamSource(source));
+	}
+
+	/**
+	 * Convert the contents of a Reader to an object of a given class.
+	 *
+	 * @param clz
+	 *            Type of object
+	 * @param source
+	 *            Reader to be read
+	 * @return Object of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> T typeFromXml(Class<T> clz, Reader source) throws JAXBException {
+		return typeFromXml(clz, new StreamSource(source));
+	}
+
+	/**
+	 * Convert the contents of an InputStream to an object of a given class.
+	 *
+	 * @param clz
+	 *            Type of object
+	 * @param source
+	 *            InputStream to be read
+	 * @return Object of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> T typeFromXml(Class<T> clz, InputStream source) throws JAXBException {
+		return typeFromXml(clz, new StreamSource(source));
+	}
+
+	/**
+	 * Convert the contents of a Source to an object of a given class.
+	 *
+	 * @param clz
+	 *            Type of object
+	 * @param source
+	 *            Source to be used
+	 * @return Object of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> T typeFromXml(Class<T> clz, Source source) throws JAXBException {
+		JAXBContext ctx = JAXBContext.newInstance(clz);
+		Unmarshaller u = ctx.createUnmarshaller();
+		return u.unmarshal(source, clz).getValue();
+	}
+
+	/**
+	 * Converts the contents of the string to a List with objects of the given
+	 * class.
+	 *
+	 * @param clz
+	 *            Type to be used
+	 * @param source
+	 *            Input string
+	 * @return List with objects of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> List<T> collectionFromXml(Class<T> clz, String source) throws JAXBException {
+		return collectionFromXml(clz, new StringReader(source));
+	}
+
+	/**
+	 * Converts the contents of the Reader to a List with objects of the given
+	 * class.
+	 *
+	 * @param clz
+	 *            Type to be used
+	 * @param source
+	 *            Input
+	 * @return List with objects of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> List<T> collectionFromXml(Class<T> clz, Reader source) throws JAXBException {
+		return collectionFromXml(clz, new StreamSource(source));
+	}
+
+	/**
+	 * Converts the contents of the InputStream to a List with objects of the
+	 * given class.
+	 *
+	 * @param clz
+	 *            Type to be used
+	 * @param source
+	 *            Input
+	 * @return List with objects of the given type
+	 * @throws JAXBException
+	 */
+	public static <T> List<T> collectionFromXml(Class<T> clz, InputStream source) throws JAXBException {
+		return collectionFromXml(clz, new StreamSource(source));
+	}
+
+	/**
+	 * Converts the contents of the Source to a List with objects of the given
+	 * class.
+	 *
+	 * @param clz
+	 *            Type to be used
+	 * @param source
+	 *            Input
+	 * @return List with objects of the given type
+	 * @throws JAXBException
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> List<T> collectionFromXml(Class<T> clz, Source source) throws JAXBException {
+		JAXBContext ctx = JAXBContext.newInstance(JAXBCollection.class, clz);
+		Unmarshaller u = ctx.createUnmarshaller();
+		JAXBCollection<T> collection = u.unmarshal(source, JAXBCollection.class).getValue();
+		return collection.getItems();
+	}
+
+	/**
+	 * Convert an object to a string.
+	 *
+	 * @param obj
+	 *            Object that needs to be serialized / marshalled.
+	 * @return String representation of obj
+	 * @throws JAXBException
+	 */
+	public static <T> String toXml(T obj, boolean format, boolean fragment) throws JAXBException {
+		StringWriter sw = new StringWriter();
+		toXml(obj, sw, format, fragment);
+		return sw.toString();
+	}
+
+	/**
+	 * Convert an object to a string and send it to a Writer.
+	 *
+	 * @param obj
+	 *            Object that needs to be serialized / marshalled
+	 * @param wr
+	 *            Writer used for outputting the marshalled object
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(T obj, Writer wr, boolean format, boolean fragment) throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(obj.getClass()), format, fragment);
+		m.marshal(obj, wr);
+	}
+
+	/**
+	 * Convert an object to a string and send it to a Writer.
+	 *
+	 * @param obj
+	 *            Object that needs to be serialized / marshalled
+	 * @param wr
+	 *            Writer used for outputting the marshalled object
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(T obj, XMLStreamWriter wr, boolean format, boolean fragment) throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(obj.getClass()), format, fragment);
+		m.marshal(obj, wr);
+	}
+
+	/**
+	 * Convert an object to a string and save it to a File.
+	 *
+	 * @param obj
+	 *            Object that needs to be serialized / marshalled
+	 * @param f
+	 *            Save file
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(T obj, File f, boolean format, boolean fragment) throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(obj.getClass()), format, fragment);
+		m.marshal(obj, f);
+	}
+
+	/**
+	 * Convert an object to a string and send it to an OutputStream.
+	 *
+	 * @param obj
+	 *            Object that needs to be serialized / marshalled
+	 * @param source
+	 *            Stream used for output
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(T obj, OutputStream source, boolean format, boolean fragment) throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(obj.getClass()), format, fragment);
+		m.marshal(obj, source);
+	}
+
+	/**
+	 * Convert a collection to a string.
+	 *
+	 * @param rootName
+	 *            Name of the XML root element
+	 * @param c
+	 *            Collection that needs to be marshalled
+	 * @return String representation of the collection
+	 * @throws JAXBException
+	 */
+	public static <T> String toXml(String rootName, Collection<T> c, boolean format, boolean fragment)
+			throws JAXBException {
+		StringWriter sw = new StringWriter();
+		toXml(rootName, c, sw, format, fragment);
+		return sw.toString();
+	}
+
+	/**
+	 * Convert a collection to a string and sends it to the Writer.
+	 *
+	 * @param rootName
+	 *            Name of the XML root element
+	 * @param c
+	 *            Collection that needs to be marshalled
+	 * @param w
+	 *            Output
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(String rootName, Collection<T> c, Writer w, boolean format, boolean fragment)
+			throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(findTypes(c)), format, fragment);
+
+		// Create wrapper collection
+		JAXBElement<?> element = createCollectionElement(rootName, c);
+		m.marshal(element, w);
+	}
+
+	/**
+	 * Convert a collection to a string and stores it in a File.
+	 *
+	 * @param rootName
+	 *            Name of the XML root element
+	 * @param c
+	 *            Collection that needs to be marshalled
+	 * @param f
+	 *            Output file
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(String rootName, Collection<T> c, File f, boolean format, boolean fragment)
+			throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(findTypes(c)), format, fragment);
+
+		// Create wrapper collection
+		JAXBElement<?> element = createCollectionElement(rootName, c);
+		m.marshal(element, f);
+	}
+
+	/**
+	 * Convert a collection to a string and sends it to the OutputStream.
+	 *
+	 * @param rootName
+	 *            Name of the XML root element
+	 * @param c
+	 *            Collection that needs to be marshalled
+	 * @param dest
+	 *            Output
+	 * @throws JAXBException
+	 */
+	public static <T> void toXml(String rootName, Collection<T> c, OutputStream dest, boolean format, boolean fragment)
+			throws JAXBException {
+		Marshaller m = marshaller(JAXBContext.newInstance(findTypes(c)), format, fragment);
+		JAXBElement<?> element = createCollectionElement(rootName, c);
+		m.marshal(element, dest);
+	}
+
+	public static <T> void schema(T obj, Writer schemaDest) throws IOException, JAXBException {
+		JAXBContext ctx = JAXBContext.newInstance(obj.getClass());
+		ctx.generateSchema(new WriterSchemaOutputResolver(schemaDest));
+	}
+
+	public static <T> void schema(T obj, OutputStream schemaDest) throws IOException, JAXBException {
+		Writer writer = new OutputStreamWriter(schemaDest);
+		schema(obj, writer);
+	}
+
+	public static <T> String schema(T obj) throws IOException, JAXBException {
+		Writer writer = new StringWriter();
+		schema(obj, writer);
+		return writer.toString();
+	}
+
+	/**
+	 * Discovers all the classes in the given Collection. These need to be in
+	 * the JAXBContext if you want to marshal those objects. Unfortunatly
+	 * there's no way of getting the generic type at runtime.
+	 *
+	 * @param c
+	 *            Collection that needs to be scanned
+	 * @return Classes found in the collection, including JAXBCollection.
+	 */
+	protected static <T> Class[] findTypes(Collection<T> c) {
+		Set<Class> types = new HashSet<>();
+		types.add(JAXBCollection.class);
+		for (T o : c) {
+			if (o != null) {
+				types.add(o.getClass());
+			}
+		}
+		return types.toArray(new Class[0]);
+	}
+
+	/**
+	 * Create a JAXBElement containing a JAXBCollection. Needed for marshalling
+	 * a generic collection without a seperate wrapper class.
+	 *
+	 * @param rootName
+	 *            Name of the XML root element
+	 * @param c
+	 * @return JAXBElement containing the given Collection, wrapped in a
+	 *         JAXBCollection.
+	 */
+	protected static <T> JAXBElement<?> createCollectionElement(String rootName, Collection<T> c) {
+		JAXBCollection<T> collection = new JAXBCollection<>(c);
+		return new JAXBElement<>(new QName(rootName), JAXBCollection.class, collection);
+	}
+
+	private static Marshaller marshaller(JAXBContext ctx, boolean format, boolean fragment) throws JAXBException {
+		Marshaller m = ctx.createMarshaller();
+		m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.valueOf(format));
+		if (fragment) {
+			m.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+		}
+		return m;
+	}
+
+	private static class WriterSchemaOutputResolver extends SchemaOutputResolver {
+		private final Writer out;
+
+		/**
+		 * @param out
+		 *            a Writer for the generated schema
+		 */
+		public WriterSchemaOutputResolver(final Writer out) {
+			super();
+			this.out = out;
+		}
+
+		/**
+		 * { @inheritDoc }
+		 */
+		@Override
+		public Result createOutput(String namespaceUri, String suggestedFileName) {
+			final StreamResult result = new StreamResult(this.out);
+			result.setSystemId(NOID);
+			return result;
+		}
+
+	}
+}

--- a/core/src/main/java/org/verapdf/model/tools/xmp/validators/DateTypeValidator.java
+++ b/core/src/main/java/org/verapdf/model/tools/xmp/validators/DateTypeValidator.java
@@ -27,7 +27,8 @@ public class DateTypeValidator implements TypeValidator {
             XMPDateTimeFactory.createFromISO8601(node.getValue());
             return true;
         } catch (XMPException e) {
-            LOGGER.log(Level.WARNING, "Node value: " + node.getValue() + " is not a valid ISO8601 date value", e);
+            LOGGER.log(Level.WARNING, "Node:" + node.getName() + " with value:" + node.getValue() + " is not a valid ISO8601 date value");
+            LOGGER.log(Level.FINE, "XMP Exception is", e);
             return false;
         }
     }

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -32,256 +32,244 @@ import org.verapdf.pdfa.results.TestAssertion.Status;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
- *
  */
 @XmlRootElement(name = "validationResult")
 final class ValidationResultImpl implements ValidationResult {
-    private final static ValidationResultImpl DEFAULT = new ValidationResultImpl();
-    @XmlAttribute
-    private final PDFAFlavour flavour;
-    @XmlAttribute
-    private final int totalAssertions;
-    @XmlElementWrapper
-    @XmlElement(name = "assertion")
-    private final Set<TestAssertion> assertions;
-    @XmlAttribute
-    private final boolean isCompliant;
+	private final static ValidationResultImpl DEFAULT = new ValidationResultImpl();
+	@XmlAttribute
+	private final PDFAFlavour flavour;
+	@XmlAttribute
+	private final int totalAssertions;
+	@XmlElementWrapper
+	@XmlElement(name = "assertion")
+	private final Set<TestAssertion> assertions;
+	@XmlAttribute
+	private final boolean isCompliant;
 
-    private ValidationResultImpl() {
-        this(PDFAFlavour.NO_FLAVOUR, Collections.<TestAssertion> emptySet(),
-                false);
-    }
+	private ValidationResultImpl() {
+		this(PDFAFlavour.NO_FLAVOUR, Collections.<TestAssertion>emptySet(), false);
+	}
 
-    private ValidationResultImpl(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions, final boolean isCompliant) {
-        this(flavour, assertions, isCompliant, assertions.size());
-    }
+	private ValidationResultImpl(final PDFAFlavour flavour, final Set<TestAssertion> assertions,
+			final boolean isCompliant) {
+		this(flavour, assertions, isCompliant, assertions.size());
+	}
 
-    private ValidationResultImpl(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions, final boolean isCompliant,
-            int totalAssertions) {
-        super();
-        this.flavour = flavour;
-        this.assertions = new HashSet<>(assertions);
-        this.isCompliant = isCompliant;
-        this.totalAssertions = totalAssertions;
-    }
+	private ValidationResultImpl(final PDFAFlavour flavour, final Set<TestAssertion> assertions,
+			final boolean isCompliant, int totalAssertions) {
+		super();
+		this.flavour = flavour;
+		this.assertions = new HashSet<>(assertions);
+		this.isCompliant = isCompliant;
+		this.totalAssertions = totalAssertions;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public boolean isCompliant() {
-        return this.isCompliant;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public boolean isCompliant() {
+		return this.isCompliant;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public PDFAFlavour getPDFAFlavour() {
-        return this.flavour;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public PDFAFlavour getPDFAFlavour() {
+		return this.flavour;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public int getTotalAssertions() {
-        return this.totalAssertions;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public int getTotalAssertions() {
+		return this.totalAssertions;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public Set<TestAssertion> getTestAssertions() {
-        return Collections.unmodifiableSet(this.assertions);
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public Set<TestAssertion> getTestAssertions() {
+		return Collections.unmodifiableSet(this.assertions);
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result
-                + ((this.assertions == null) ? 0 : this.assertions.hashCode());
-        result = prime * result + ((this.flavour == null) ? 0 : this.flavour.hashCode());
-        result = prime * result + (this.isCompliant ? 1231 : 1237);
-        result = prime * result + this.totalAssertions;
-        return result;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.assertions == null) ? 0 : this.assertions.hashCode());
+		result = prime * result + ((this.flavour == null) ? 0 : this.flavour.hashCode());
+		result = prime * result + (this.isCompliant ? 1231 : 1237);
+		result = prime * result + this.totalAssertions;
+		return result;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        if (!(obj instanceof ValidationResult))
-            return false;
-        ValidationResult other = (ValidationResult) obj;
-        if (this.assertions == null) {
-            if (other.getTestAssertions() != null)
-                return false;
-        } else if (other.getTestAssertions() == null)
-            return false;
-        else if (!this.assertions.equals(other.getTestAssertions()))
-            return false;
-        if (this.flavour != other.getPDFAFlavour())
-            return false;
-        if (this.isCompliant != other.isCompliant())
-            return false;
-        if (this.totalAssertions != other.getTotalAssertions())
-            return false;
-        return true;
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!(obj instanceof ValidationResult))
+			return false;
+		ValidationResult other = (ValidationResult) obj;
+		if (this.assertions == null) {
+			if (other.getTestAssertions() != null)
+				return false;
+		} else if (other.getTestAssertions() == null)
+			return false;
+		else if (!this.assertions.equals(other.getTestAssertions()))
+			return false;
+		if (this.flavour != other.getPDFAFlavour())
+			return false;
+		if (this.isCompliant != other.isCompliant())
+			return false;
+		if (this.totalAssertions != other.getTotalAssertions())
+			return false;
+		return true;
+	}
 
-    /**
-     * { @inheritDoc }
-     */
-    @Override
-    public String toString() {
-        return "ValidationResult [flavour=" + this.flavour + ", totalAssertions="
-                + this.totalAssertions + ", assertions=" + this.assertions + ", isCompliant="
-                + this.isCompliant + "]";
-    }
+	/**
+	 * { @inheritDoc }
+	 */
+	@Override
+	public String toString() {
+		return "ValidationResult [flavour=" + this.flavour + ", totalAssertions=" + this.totalAssertions
+				+ ", assertions=" + this.assertions + ", isCompliant=" + this.isCompliant + "]";
+	}
 
-    static ValidationResultImpl defaultInstance() {
-        return DEFAULT;
-    }
+	static ValidationResultImpl defaultInstance() {
+		return DEFAULT;
+	}
 
-    static ValidationResultImpl fromValues(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions, final boolean isCompliant, final int totalChecks) {
-        return new ValidationResultImpl(flavour, assertions, isCompliant, totalChecks);
-    }
+	static ValidationResultImpl fromValues(final PDFAFlavour flavour, final Set<TestAssertion> assertions,
+			final boolean isCompliant, final int totalChecks) {
+		return new ValidationResultImpl(flavour, assertions, isCompliant, totalChecks);
+	}
 
-    static ValidationResultImpl fromValidationResult(ValidationResult toConvert) {
-        return fromValues(toConvert.getPDFAFlavour(),
-                toConvert.getTestAssertions(), toConvert.isCompliant(), toConvert.getTotalAssertions());
-    }
+	static ValidationResultImpl fromValidationResult(ValidationResult toConvert) {
+		return fromValues(toConvert.getPDFAFlavour(), toConvert.getTestAssertions(), toConvert.isCompliant(),
+				toConvert.getTotalAssertions());
+	}
 
-    static ValidationResultImpl stripPassedTests(ValidationResult toStrip) {
-        return fromValues(toStrip.getPDFAFlavour(),
-                stripPassedTests(toStrip.getTestAssertions()), toStrip.isCompliant(), toStrip.getTotalAssertions());
-    }
+	static ValidationResultImpl stripPassedTests(ValidationResult toStrip) {
+		return fromValues(toStrip.getPDFAFlavour(), stripPassedTests(toStrip.getTestAssertions()),
+				toStrip.isCompliant(), toStrip.getTotalAssertions());
+	}
 
-    static String toXml(final ValidationResult toConvert, Boolean prettyXml)
-            throws JAXBException, IOException {
-        String retVal = "";
-        try (StringWriter writer = new StringWriter()) {
-            toXml(toConvert, writer, prettyXml);
-            retVal = writer.toString();
-            return retVal;
-        }
-    }
+	static String toXml(final ValidationResult toConvert, boolean prettyXml) throws JAXBException, IOException {
+		String retVal = "";
+		try (StringWriter writer = new StringWriter()) {
+			toXml(toConvert, writer, prettyXml, true);
+			retVal = writer.toString();
+			return retVal;
+		}
+	}
 
-    static void toXml(final ValidationResult toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-        Marshaller varMarshaller = getMarshaller(prettyXml);
-        varMarshaller.marshal(toConvert, stream);
-    }
+	static void toXml(final ValidationResult toConvert, final OutputStream stream, boolean prettyXml, boolean fragment)
+			throws JAXBException {
+		Marshaller varMarshaller = getMarshaller(prettyXml, fragment);
+		varMarshaller.marshal(toConvert, stream);
+	}
 
-    static ValidationResultImpl fromXml(final InputStream toConvert)
-            throws JAXBException {
-        Unmarshaller stringUnmarshaller = getUnmarshaller();
-        return (ValidationResultImpl) stringUnmarshaller.unmarshal(toConvert);
-    }
+	static ValidationResultImpl fromXml(final InputStream toConvert) throws JAXBException {
+		Unmarshaller stringUnmarshaller = getUnmarshaller();
+		return (ValidationResultImpl) stringUnmarshaller.unmarshal(toConvert);
+	}
 
-    static void toXml(final ValidationResult toConvert, final Writer writer,
-            Boolean prettyXml) throws JAXBException {
-        Marshaller varMarshaller = getMarshaller(prettyXml);
-        varMarshaller.marshal(toConvert, writer);
-    }
+	static void toXml(final ValidationResult toConvert, final Writer writer, boolean prettyXml, boolean fragment)
+			throws JAXBException {
+		Marshaller varMarshaller = getMarshaller(prettyXml, fragment);
+		varMarshaller.marshal(toConvert, writer);
+	}
 
-    static ValidationResultImpl fromXml(final Reader toConvert)
-            throws JAXBException {
-        Unmarshaller stringUnmarshaller = getUnmarshaller();
-        return (ValidationResultImpl) stringUnmarshaller.unmarshal(toConvert);
-    }
+	static ValidationResultImpl fromXml(final Reader toConvert) throws JAXBException {
+		Unmarshaller stringUnmarshaller = getUnmarshaller();
+		return (ValidationResultImpl) stringUnmarshaller.unmarshal(toConvert);
+	}
 
-    static ValidationResultImpl fromXml(final String toConvert)
-            throws JAXBException {
-        try (StringReader reader = new StringReader(toConvert)) {
-            return fromXml(reader);
-        }
-    }
+	static ValidationResultImpl fromXml(final String toConvert) throws JAXBException {
+		try (StringReader reader = new StringReader(toConvert)) {
+			return fromXml(reader);
+		}
+	}
 
-    static class Adapter extends
-            XmlAdapter<ValidationResultImpl, ValidationResult> {
-        @Override
-        public ValidationResult unmarshal(
-                ValidationResultImpl validationResultImpl) {
-            return validationResultImpl;
-        }
+	static class Adapter extends XmlAdapter<ValidationResultImpl, ValidationResult> {
+		@Override
+		public ValidationResult unmarshal(ValidationResultImpl validationResultImpl) {
+			return validationResultImpl;
+		}
 
-        @Override
-        public ValidationResultImpl marshal(ValidationResult validationResult) {
-            return (ValidationResultImpl) validationResult;
-        }
-    }
+		@Override
+		public ValidationResultImpl marshal(ValidationResult validationResult) {
+			return (ValidationResultImpl) validationResult;
+		}
+	}
 
-    static String getSchema() throws JAXBException, IOException {
-        JAXBContext context = JAXBContext
-                .newInstance(ValidationResultImpl.class);
-        final StringWriter writer = new StringWriter();
-        context.generateSchema(new WriterSchemaOutputResolver(writer));
-        return writer.toString();
-    }
+	static String getSchema() throws JAXBException, IOException {
+		JAXBContext context = JAXBContext.newInstance(ValidationResultImpl.class);
+		final StringWriter writer = new StringWriter();
+		context.generateSchema(new WriterSchemaOutputResolver(writer));
+		return writer.toString();
+	}
 
-    private static Unmarshaller getUnmarshaller() throws JAXBException {
-        JAXBContext context = JAXBContext
-                .newInstance(ValidationResultImpl.class);
-        Unmarshaller unmarshaller = context.createUnmarshaller();
-        return unmarshaller;
-    }
+	private static Unmarshaller getUnmarshaller() throws JAXBException {
+		JAXBContext context = JAXBContext.newInstance(ValidationResultImpl.class);
+		Unmarshaller unmarshaller = context.createUnmarshaller();
+		return unmarshaller;
+	}
 
-    private static Marshaller getMarshaller(Boolean setPretty)
-            throws JAXBException {
-        JAXBContext context = JAXBContext
-                .newInstance(ValidationResultImpl.class);
-        Marshaller marshaller = context.createMarshaller();
-        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, setPretty);
-        return marshaller;
-    }
+	private static Marshaller getMarshaller(boolean prettyXml, boolean fragment) throws JAXBException {
+		JAXBContext context = JAXBContext.newInstance(ValidationResultImpl.class);
+		Marshaller marshaller = context.createMarshaller();
+		marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.valueOf(prettyXml));
+		if (fragment) {
+			marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+		}
+		return marshaller;
+	}
 
-    static Set<TestAssertion> stripPassedTests(
-            final Set<TestAssertion> toStrip) {
-        Set<TestAssertion> strippedSet = new HashSet<>();
-        for (TestAssertion test : toStrip) {
-            if (test.getStatus() != Status.PASSED)
-                strippedSet.add(test);
-        }
-        return strippedSet;
-    }
+	static Set<TestAssertion> stripPassedTests(final Set<TestAssertion> toStrip) {
+		Set<TestAssertion> strippedSet = new HashSet<>();
+		for (TestAssertion test : toStrip) {
+			if (test.getStatus() != Status.PASSED)
+				strippedSet.add(test);
+		}
+		return strippedSet;
+	}
 
-    private static class WriterSchemaOutputResolver extends SchemaOutputResolver {
-        private final Writer out;
-        /**
-         * @param out a Writer for the generated schema
-         * 
-         */
-        public WriterSchemaOutputResolver(final Writer out) {
-            super();
-            this.out = out;
-        }
+	private static class WriterSchemaOutputResolver extends SchemaOutputResolver {
+		private final Writer out;
 
-        /**
-         * { @inheritDoc }
-         */
-        @Override
-        public Result createOutput(String namespaceUri, String suggestedFileName) {
-            final StreamResult result = new StreamResult(this.out);
-            result.setSystemId("no-id");
-            return result;
-        }
+		/**
+		 * @param out
+		 *            a Writer for the generated schema
+		 */
+		public WriterSchemaOutputResolver(final Writer out) {
+			super();
+			this.out = out;
+		}
 
-    }
+		/**
+		 * { @inheritDoc }
+		 */
+		@Override
+		public Result createOutput(String namespaceUri, String suggestedFileName) {
+			final StreamResult result = new StreamResult(this.out);
+			result.setSystemId("no-id");
+			return result;
+		}
+
+	}
 }

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -20,317 +20,305 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
- *
  */
 public class ValidationResults {
-    private static final String NOT_NULL_MESSAGE = " cannot be null.";
-    private static final String FLAVOUR_NOT_NULL_MESSAGE = "Flavour " + NOT_NULL_MESSAGE;
-    private static final String ASSERTIONS_NOT_NULL_MESSAGE = "Assertions " + NOT_NULL_MESSAGE;
-    private ValidationResults() {
-        throw new AssertionError("Should never enter ValidationResults().");
-    }
+	private static final String NOT_NULL_MESSAGE = " cannot be null.";
+	private static final String FLAVOUR_NOT_NULL_MESSAGE = "Flavour " + NOT_NULL_MESSAGE;
+	private static final String ASSERTIONS_NOT_NULL_MESSAGE = "Assertions " + NOT_NULL_MESSAGE;
 
-    /**
-     * @param flavour
-     *            a {@link PDFAFlavour} instance indicating the validation type
-     *            performed
-     * @param assertions
-     *            the Set of TestAssertions reported by during validation
-     * @param isCompliant
-     *            a boolean that indicating whether the validated PDF/A data was
-     *            compliant with the indicated flavour
-     * @return a new ValidationResult instance populated from the values
-     */
-    public static ValidationResult resultFromValues(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions, final boolean isCompliant) {
-        if (flavour == null)
-            throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
-        if (assertions == null)
-            throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
-        return ValidationResultImpl.fromValues(flavour, assertions,
-                isCompliant, assertions.size());
-    }
+	private ValidationResults() {
+		throw new AssertionError("Should never enter ValidationResults().");
+	}
 
-    /**
-     * @param flavour
-     *            a {@link PDFAFlavour} instance indicating the validation type
-     *            performed
-     * @param assertions
-     *            the Set of TestAssertions reported by during validation
-     * @param isCompliant
-     *            a boolean that indicating whether the validated PDF/A data was
-     *            compliant with the indicated flavour
-     * @param totalAssertions
-     * @return a new ValidationResult instance populated from the values
-     */
-    public static ValidationResult resultFromValues(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions, final boolean isCompliant,
-            final int totalAssertions) {
-        if (flavour == null)
-            throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
-        if (assertions == null)
-            throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
-        return ValidationResultImpl.fromValues(flavour, assertions,
-                isCompliant, totalAssertions);
-    }
+	/**
+	 * @param flavour
+	 *            a {@link PDFAFlavour} instance indicating the validation type
+	 *            performed
+	 * @param assertions
+	 *            the Set of TestAssertions reported by during validation
+	 * @param isCompliant
+	 *            a boolean that indicating whether the validated PDF/A data was
+	 *            compliant with the indicated flavour
+	 * @return a new ValidationResult instance populated from the values
+	 */
+	public static ValidationResult resultFromValues(final PDFAFlavour flavour, final Set<TestAssertion> assertions,
+			final boolean isCompliant) {
+		if (flavour == null)
+			throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
+		if (assertions == null)
+			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
+		return ValidationResultImpl.fromValues(flavour, assertions, isCompliant, assertions.size());
+	}
 
-    /**
-     * @param flavour
-     *            a {@link PDFAFlavour} instance indicating the validation type
-     *            performed
-     * @param assertions
-     *            the Set of TestAssertions reported by during validation
-     * @return a new ValidationResult instance populated from the values
-     */
-    public static ValidationResult resultFromValues(final PDFAFlavour flavour,
-            final Set<TestAssertion> assertions) {
-        if (flavour == null)
-            throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
-        if (assertions == null)
-            throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
-        boolean isCompliant = true;
-        for (TestAssertion assertion : assertions) {
-            if (assertion.getStatus() == Status.FAILED) {
-                isCompliant = false;
-                break;
-            }
-        }
-        return resultFromValues(flavour, assertions, isCompliant);
-    }
+	/**
+	 * @param flavour
+	 *            a {@link PDFAFlavour} instance indicating the validation type
+	 *            performed
+	 * @param assertions
+	 *            the Set of TestAssertions reported by during validation
+	 * @param isCompliant
+	 *            a boolean that indicating whether the validated PDF/A data was
+	 *            compliant with the indicated flavour
+	 * @param totalAssertions
+	 * @return a new ValidationResult instance populated from the values
+	 */
+	public static ValidationResult resultFromValues(final PDFAFlavour flavour, final Set<TestAssertion> assertions,
+			final boolean isCompliant, final int totalAssertions) {
+		if (flavour == null)
+			throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
+		if (assertions == null)
+			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
+		return ValidationResultImpl.fromValues(flavour, assertions, isCompliant, totalAssertions);
+	}
 
-    /**
-     * Returns an immutable default instance of a ValidationResult. This is a
-     * static single instance, i.e.
-     * <code>ValidationResults.defaultResult() == ValidationResults.defaultResult()</code>
-     * is always true.
-     *
-     * @return the default ValidationResult instance
-     */
-    public static ValidationResult defaultResult() {
-        return ValidationResultImpl.defaultInstance();
-    }
+	/**
+	 * @param flavour
+	 *            a {@link PDFAFlavour} instance indicating the validation type
+	 *            performed
+	 * @param assertions
+	 *            the Set of TestAssertions reported by during validation
+	 * @return a new ValidationResult instance populated from the values
+	 */
+	public static ValidationResult resultFromValues(final PDFAFlavour flavour, final Set<TestAssertion> assertions) {
+		if (flavour == null)
+			throw new NullPointerException(FLAVOUR_NOT_NULL_MESSAGE);
+		if (assertions == null)
+			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
+		boolean isCompliant = true;
+		for (TestAssertion assertion : assertions) {
+			if (assertion.getStatus() == Status.FAILED) {
+				isCompliant = false;
+				break;
+			}
+		}
+		return resultFromValues(flavour, assertions, isCompliant);
+	}
 
-    /**
-     * Creates an immutable TestAssertion instance from the passed parameter
-     * values.
-     * 
-     * @param ordinal
-     *            the integer ordinal for the instance
-     * @param ruleId
-     *            the {@link RuleId} value for
-     *            {@link org.verapdf.pdfa.validation.Rule} the assertion refers
-     *            to.
-     * @param status
-     *            the {@link Status} of the assertion.
-     * @param message
-     *            any String message to be associated with the assertion.
-     * @param location
-     *            a {@link Location} instance indicating the location within the
-     *            PDF document where the test was performed.
-     * @return an immutable TestAssertion instance initialised using the passed
-     *         values
-     */
-    public static TestAssertion assertionFromValues(final int ordinal,
-            final RuleId ruleId, final Status status, final String message,
-            final Location location) {
-        return TestAssertionImpl.fromValues(ordinal, ruleId, status, message,
-                location);
-    }
+	/**
+	 * Returns an immutable default instance of a ValidationResult. This is a
+	 * static single instance, i.e.
+	 * <code>ValidationResults.defaultResult() == ValidationResults.defaultResult()</code>
+	 * is always true.
+	 *
+	 * @return the default ValidationResult instance
+	 */
+	public static ValidationResult defaultResult() {
+		return ValidationResultImpl.defaultInstance();
+	}
 
-    /**
-     * Returns an immutable default instance of a TestAssertion. This is a
-     * static single instance, i.e.
-     * <code>ValidationResults.defaultAssertion() == ValidationResults.defaultAssertion()</code>
-     * is always true.
-     *
-     * @return the default TestAssertion instance
-     */
-    public static TestAssertion defaultAssertion() {
-        return TestAssertionImpl.defaultInstance();
-    }
+	/**
+	 * Creates an immutable TestAssertion instance from the passed parameter
+	 * values.
+	 * 
+	 * @param ordinal
+	 *            the integer ordinal for the instance
+	 * @param ruleId
+	 *            the {@link RuleId} value for
+	 *            {@link org.verapdf.pdfa.validation.Rule} the assertion refers
+	 *            to.
+	 * @param status
+	 *            the {@link Status} of the assertion.
+	 * @param message
+	 *            any String message to be associated with the assertion.
+	 * @param location
+	 *            a {@link Location} instance indicating the location within the
+	 *            PDF document where the test was performed.
+	 * @return an immutable TestAssertion instance initialised using the passed
+	 *         values
+	 */
+	public static TestAssertion assertionFromValues(final int ordinal, final RuleId ruleId, final Status status,
+			final String message, final Location location) {
+		return TestAssertionImpl.fromValues(ordinal, ruleId, status, message, location);
+	}
 
-    /**
-     * TODO: Better explanation of level and context. Creates an immutable
-     * {@link Location} instance.
-     * 
-     * @param level
-     *            the Locations level, represented as a String
-     * @param context
-     *            the Locations context, represented as a String
-     * @return and immutable Location instance initialised with the passed
-     *         values.
-     */
-    public static Location locationFromValues(final String level,
-            final String context) {
-        return LocationImpl.fromValues(level, context);
-    }
+	/**
+	 * Returns an immutable default instance of a TestAssertion. This is a
+	 * static single instance, i.e.
+	 * <code>ValidationResults.defaultAssertion() == ValidationResults.defaultAssertion()</code>
+	 * is always true.
+	 *
+	 * @return the default TestAssertion instance
+	 */
+	public static TestAssertion defaultAssertion() {
+		return TestAssertionImpl.defaultInstance();
+	}
 
-    /**
-     * Returns an immutable default instance of a Location. This is a static
-     * single instance, i.e.
-     * <code>ValidationResults.defaultLocation() == ValidationResults.defaultLocation()</code>
-     * is always true.
-     *
-     * @return the default Location instance
-     */
-    public static Location defaultLocation() {
-        return LocationImpl.defaultInstance();
-    }
+	/**
+	 * TODO: Better explanation of level and context. Creates an immutable
+	 * {@link Location} instance.
+	 * 
+	 * @param level
+	 *            the Locations level, represented as a String
+	 * @param context
+	 *            the Locations context, represented as a String
+	 * @return and immutable Location instance initialised with the passed
+	 *         values.
+	 */
+	public static Location locationFromValues(final String level, final String context) {
+		return LocationImpl.fromValues(level, context);
+	}
 
-    /**
-     * Converts a {@link ValidationResult} instance into an XML String. The
-     * returned String can be de-serialised from XML to a
-     * {@link ValidationResult} instance by passing it to the
-     * {@link ValidationResults#fromXml(String)} method.
-     * 
-     * @param toConvert
-     *            a ValidationResult instance to covert to XML
-     * @param prettyXml
-     *            controls formatting of the returned XML, {@link Boolean#TRUE}
-     *            requests pretty formatting, e.g. new lines and indentation,
-     *            {@link Boolean#FALSE} indicates no formatting is required.
-     * @return the XML representation of the ValidationResult passed as
-     *         <code>toConvert</code>.
-     * @throws JAXBException
-     *             this occurs if there's a problem converting the passed type
-     *             to XML
-     * @throws IOException
-     *             if a problem occurs writing the converted result to a String.
-     */
-    public static String resultToXml(final ValidationResult toConvert,
-            Boolean prettyXml) throws JAXBException, IOException {
-        try (StringWriter writer = new StringWriter()) {
-            toXml(toConvert, writer, prettyXml);
-            return writer.toString();
-        }
-    }
+	/**
+	 * Returns an immutable default instance of a Location. This is a static
+	 * single instance, i.e.
+	 * <code>ValidationResults.defaultLocation() == ValidationResults.defaultLocation()</code>
+	 * is always true.
+	 *
+	 * @return the default Location instance
+	 */
+	public static Location defaultLocation() {
+		return LocationImpl.defaultInstance();
+	}
 
-    /**
-     * Converts an XML representation of a {@link ValidationResult} into a
-     * ValidationResult instance.
-     * 
-     * @param toConvert
-     *            a String holding an XML serialisation of a ValidationResult.
-     * @return an immutable ValidationResult instance initialised using the
-     *         passed XML String
-     * @throws JAXBException
-     *             when there's an error converting the XML
-     */
-    public static ValidationResult fromXml(final String toConvert)
-            throws JAXBException {
-        try (StringReader reader = new StringReader(toConvert)) {
-            return fromXml(reader);
-        }
-    }
+	/**
+	 * Converts a {@link ValidationResult} instance into an XML String. The
+	 * returned String can be de-serialised from XML to a
+	 * {@link ValidationResult} instance by passing it to the
+	 * {@link ValidationResults#fromXml(String)} method.
+	 * 
+	 * @param toConvert
+	 *            a ValidationResult instance to covert to XML
+	 * @param prettyXml
+	 *            controls formatting of the returned XML, {@link Boolean#TRUE}
+	 *            requests pretty formatting, e.g. new lines and indentation,
+	 *            {@link Boolean#FALSE} indicates no formatting is required.
+	 * @return the XML representation of the ValidationResult passed as
+	 *         <code>toConvert</code>.
+	 * @throws JAXBException
+	 *             this occurs if there's a problem converting the passed type
+	 *             to XML
+	 * @throws IOException
+	 *             if a problem occurs writing the converted result to a String.
+	 */
+	public static String resultToXml(final ValidationResult toConvert, boolean prettyXml)
+			throws JAXBException, IOException {
+		try (StringWriter writer = new StringWriter()) {
+			toXml(toConvert, writer, prettyXml, true);
+			return writer.toString();
+		}
+	}
 
-    /**
-     * Converts a {@link ValidationResult} instance into XML which is written to
-     * the passed <code>stream</code>.
-     * 
-     * @param toConvert
-     *            a ValidationResult instance to covert to XML
-     * @param stream
-     *            an OutputStream, the destination where the XML representation
-     *            of the ValidationResult will be written.
-     * @param prettyXml
-     *            controls formatting of the returned XML, {@link Boolean#TRUE}
-     *            requests pretty formatting, e.g. new lines and indentation,
-     *            {@link Boolean#FALSE} indicates no formatting is required.
-     * @throws JAXBException
-     *             this occurs if there's a problem converting the passed type
-     *             to XML
-     */
-    public static void toXml(final ValidationResult toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-        ValidationResultImpl.toXml(toConvert, stream, prettyXml);
-    }
+	/**
+	 * Converts an XML representation of a {@link ValidationResult} into a
+	 * ValidationResult instance.
+	 * 
+	 * @param toConvert
+	 *            a String holding an XML serialisation of a ValidationResult.
+	 * @return an immutable ValidationResult instance initialised using the
+	 *         passed XML String
+	 * @throws JAXBException
+	 *             when there's an error converting the XML
+	 */
+	public static ValidationResult fromXml(final String toConvert) throws JAXBException {
+		try (StringReader reader = new StringReader(toConvert)) {
+			return fromXml(reader);
+		}
+	}
 
-    /**
-     * Converts an XML representation of a {@link ValidationResult} into a
-     * ValidationResult instance.
-     * 
-     * @param toConvert
-     *            an ImputStream holding an XML serialisation of a
-     *            ValidationResult.
-     * @return an immutable ValidationResult instance initialised using the
-     *         contents of the passed InputStream <code>toConvert</code>.
-     * @throws JAXBException
-     *             when there's an error converting the XML
-     */
-    public static ValidationResult fromXml(final InputStream toConvert)
-            throws JAXBException {
-        return ValidationResultImpl.fromXml(toConvert);
-    }
+	/**
+	 * Converts a {@link ValidationResult} instance into XML which is written to
+	 * the passed <code>stream</code>.
+	 * 
+	 * @param toConvert
+	 *            a ValidationResult instance to covert to XML
+	 * @param stream
+	 *            an OutputStream, the destination where the XML representation
+	 *            of the ValidationResult will be written.
+	 * @param prettyXml
+	 *            controls formatting of the returned XML, {@link Boolean#TRUE}
+	 *            requests pretty formatting, e.g. new lines and indentation,
+	 *            {@link Boolean#FALSE} indicates no formatting is required.
+	 * @throws JAXBException
+	 *             this occurs if there's a problem converting the passed type
+	 *             to XML
+	 */
+	public static void toXml(final ValidationResult toConvert, final OutputStream stream, boolean prettyXml,
+			boolean fragment) throws JAXBException {
+		ValidationResultImpl.toXml(toConvert, stream, prettyXml, fragment);
+	}
 
-    /**
-     * Converts a {@link ValidationResult} instance into XML which is written to
-     * the passed <code>writer</code>.
-     * 
-     * @param toConvert
-     *            a ValidationResult instance to covert to XML
-     * @param writer
-     *            an {@link Writer} instance, the destination where the XML
-     *            representation of the ValidationResult will be written.
-     * @param prettyXml
-     *            controls formatting of the returned XML, {@link Boolean#TRUE}
-     *            requests pretty formatting, e.g. new lines and indentation,
-     *            {@link Boolean#FALSE} indicates no formatting is required.
-     * @throws JAXBException
-     *             this occurs if there's a problem converting the passed type
-     *             to XML
-     */
-    public static void toXml(final ValidationResult toConvert,
-            final Writer writer, Boolean prettyXml) throws JAXBException {
-        ValidationResultImpl.toXml(toConvert, writer, prettyXml);
-    }
+	/**
+	 * Converts an XML representation of a {@link ValidationResult} into a
+	 * ValidationResult instance.
+	 * 
+	 * @param toConvert
+	 *            an ImputStream holding an XML serialisation of a
+	 *            ValidationResult.
+	 * @return an immutable ValidationResult instance initialised using the
+	 *         contents of the passed InputStream <code>toConvert</code>.
+	 * @throws JAXBException
+	 *             when there's an error converting the XML
+	 */
+	public static ValidationResult fromXml(final InputStream toConvert) throws JAXBException {
+		return ValidationResultImpl.fromXml(toConvert);
+	}
 
-    /**
-     * Converts an XML representation of a {@link ValidationResult} into a
-     * ValidationResult instance.
-     * 
-     * @param toConvert
-     *            a Reader instance, holding an XML serialisation of a
-     *            ValidationResult.
-     * @return an immutable ValidationResult instance initialised using the
-     *         contents of the passed InputStream <code>toConvert</code>.
-     * @throws JAXBException
-     *             when there's an error converting the XML
-     */
-    public static ValidationResult fromXml(final Reader toConvert)
-            throws JAXBException {
-        return ValidationResultImpl.fromXml(toConvert);
-    }
+	/**
+	 * Converts a {@link ValidationResult} instance into XML which is written to
+	 * the passed <code>writer</code>.
+	 * 
+	 * @param toConvert
+	 *            a ValidationResult instance to covert to XML
+	 * @param writer
+	 *            an {@link Writer} instance, the destination where the XML
+	 *            representation of the ValidationResult will be written.
+	 * @param prettyXml
+	 *            controls formatting of the returned XML, {@link Boolean#TRUE}
+	 *            requests pretty formatting, e.g. new lines and indentation,
+	 *            {@link Boolean#FALSE} indicates no formatting is required.
+	 * @throws JAXBException
+	 *             this occurs if there's a problem converting the passed type
+	 *             to XML
+	 */
+	public static void toXml(final ValidationResult toConvert, final Writer writer, boolean prettyXml, boolean fragment)
+			throws JAXBException {
+		ValidationResultImpl.toXml(toConvert, writer, prettyXml, fragment);
+	}
 
+	/**
+	 * Converts an XML representation of a {@link ValidationResult} into a
+	 * ValidationResult instance.
+	 * 
+	 * @param toConvert
+	 *            a Reader instance, holding an XML serialisation of a
+	 *            ValidationResult.
+	 * @return an immutable ValidationResult instance initialised using the
+	 *         contents of the passed InputStream <code>toConvert</code>.
+	 * @throws JAXBException
+	 *             when there's an error converting the XML
+	 */
+	public static ValidationResult fromXml(final Reader toConvert) throws JAXBException {
+		return ValidationResultImpl.fromXml(toConvert);
+	}
 
-    /**
-     * Returns the JAXB generated XML schema for the ValidationProfileImpl type.
-     * 
-     * @return the String representation of the schema
-     * @throws JAXBException
-     *             if there's a problem marshaling the schema
-     * @throws IOException
-     *             if there's a problem outputting the result
-     */
-    public static String getValidationResultSchema() throws JAXBException,
-            IOException {
-        return ValidationResultImpl.getSchema();
-    }
+	/**
+	 * Returns the JAXB generated XML schema for the ValidationProfileImpl type.
+	 * 
+	 * @return the String representation of the schema
+	 * @throws JAXBException
+	 *             if there's a problem marshaling the schema
+	 * @throws IOException
+	 *             if there's a problem outputting the result
+	 */
+	public static String getValidationResultSchema() throws JAXBException, IOException {
+		return ValidationResultImpl.getSchema();
+	}
 
-    /**
-     * Strips any {@link TestAssertion}s where
-     * {@code assertion.getStatus() == TestAssertion.Status.PASSED} from
-     * {@code toStrip} and returns a new {@link ValidationResult} without the
-     * passed assertions.
-     * 
-     * @param toStrip
-     *            a {@code ValidationResult} to clone without passed
-     *            {@code TestAssertion}s
-     * @return a ValidationResult instance identical to {@code toStrip}, but
-     *         without passed {@code TestAssertion}s.
-     */
-    public static ValidationResult stripPassedTests(ValidationResult toStrip) {
-        if (toStrip == null)
-            throw new NullPointerException("toStrip can not be null.");
-        return ValidationResultImpl.stripPassedTests(toStrip);
-    }
+	/**
+	 * Strips any {@link TestAssertion}s where
+	 * {@code assertion.getStatus() == TestAssertion.Status.PASSED} from
+	 * {@code toStrip} and returns a new {@link ValidationResult} without the
+	 * passed assertions.
+	 * 
+	 * @param toStrip
+	 *            a {@code ValidationResult} to clone without passed
+	 *            {@code TestAssertion}s
+	 * @return a ValidationResult instance identical to {@code toStrip}, but
+	 *         without passed {@code TestAssertion}s.
+	 */
+	public static ValidationResult stripPassedTests(ValidationResult toStrip) {
+		if (toStrip == null)
+			throw new NullPointerException("toStrip can not be null.");
+		return ValidationResultImpl.stripPassedTests(toStrip);
+	}
 }

--- a/core/src/main/java/org/verapdf/processor/BatchSummary.java
+++ b/core/src/main/java/org/verapdf/processor/BatchSummary.java
@@ -1,0 +1,22 @@
+package org.verapdf.processor;
+
+import org.verapdf.component.AuditDuration;
+
+public interface BatchSummary {
+
+	/**
+	 * @return the duration
+	 */
+	AuditDuration getDuration();
+
+	/**
+	 * @return the jobs
+	 */
+	int getJobs();
+
+	/**
+	 * @return the failedJobs
+	 */
+	int getFailedJobs();
+
+}

--- a/core/src/main/java/org/verapdf/processor/BatchSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/BatchSummaryImpl.java
@@ -1,0 +1,63 @@
+/**
+ * 
+ */
+package org.verapdf.processor;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+
+import org.verapdf.component.AuditDuration;
+
+/**
+ * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ *
+ * @version 0.1
+ * 
+ * Created 2 Nov 2016:11:43:50
+ */
+
+final class BatchSummaryImpl implements BatchSummary {
+	@XmlElement
+	private final AuditDuration duration;
+	@XmlAttribute
+	private final int jobs;
+	@XmlAttribute
+	private final int failedJobs;
+
+	/**
+	 * @param duration
+	 * @param jobs
+	 * @param failedJobs
+	 */
+	private BatchSummaryImpl(AuditDuration duration, int jobs, int failedJobs) {
+		super();
+		this.duration = duration;
+		this.jobs = jobs;
+		this.failedJobs = failedJobs;
+	}
+
+	/**
+	 * @return the duration
+	 */
+	@Override
+	public AuditDuration getDuration() {
+		return this.duration;
+	}
+
+	/**
+	 * @return the jobs
+	 */
+	@Override
+	public int getJobs() {
+		return this.jobs;
+	}
+
+	/**
+	 * @return the failedJobs
+	 */
+	@Override
+	public int getFailedJobs() {
+		return this.failedJobs;
+	}
+}

--- a/core/src/main/java/org/verapdf/processor/ItemProcessor.java
+++ b/core/src/main/java/org/verapdf/processor/ItemProcessor.java
@@ -1,12 +1,10 @@
 package org.verapdf.processor;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.util.Set;
 
-import org.verapdf.component.Component;
 import org.verapdf.report.ItemDetails;
-import org.verapdf.report.MachineReadableReport;
 
 /**
  * Processor encapsulates all validation processes: validation, metadata fixes
@@ -14,7 +12,7 @@ import org.verapdf.report.MachineReadableReport;
  *
  * @author Sergey Shemyakov
  */
-public interface VeraProcessor extends Component {
+public interface ItemProcessor extends Processor {
 
 	/**
 	 * Method performs pdf validation with given options
@@ -30,9 +28,5 @@ public interface VeraProcessor extends Component {
 	 */
 	public ProcessorResult process(ItemDetails fileDetails, InputStream toProcess);
 
-	public Set<ProcessorResult> process(Set<File> toProcess);
-	
-	public MachineReadableReport processBatch(Set<File> toProcess); 
-
-	public ProcessorConfig getConfig();
+	public ProcessorResult process(File toProcess) throws FileNotFoundException;
 }

--- a/core/src/main/java/org/verapdf/processor/Processor.java
+++ b/core/src/main/java/org/verapdf/processor/Processor.java
@@ -1,0 +1,23 @@
+/**
+ * 
+ */
+package org.verapdf.processor;
+
+import java.util.Collection;
+
+import org.verapdf.ReleaseDetails;
+import org.verapdf.component.Component;
+
+/**
+ * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ *
+ * @version 0.1
+ * 
+ * Created 2 Nov 2016:11:22:06
+ */
+
+public interface Processor extends Component {
+	public ProcessorConfig getConfig();
+	public Collection<ReleaseDetails> getDependencies();
+}

--- a/core/src/main/java/org/verapdf/processor/ProcessorFactory.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorFactory.java
@@ -32,39 +32,40 @@ public final class ProcessorFactory {
 			final MetadataFixerConfig fixerConfig, final EnumSet<TaskType> tasks) {
 		return ProcessorConfigImpl.fromValues(config, featureConfig, fixerConfig, tasks);
 	}
-	
-    public static void configToXml(final ProcessorConfig toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-    	ProcessorConfigImpl.toXml(toConvert, stream, prettyXml);
-    }
 
-    public static ProcessorConfig configFromXml(final InputStream toConvert)
-            throws JAXBException {
-    	return ProcessorConfigImpl.fromXml(toConvert);
-    }
+	public static void configToXml(final ProcessorConfig toConvert, final OutputStream stream, Boolean prettyXml)
+			throws JAXBException {
+		ProcessorConfigImpl.toXml(toConvert, stream, prettyXml);
+	}
 
-	public static final VeraProcessor createProcessor(final ProcessorConfig config) {
+	public static ProcessorConfig configFromXml(final InputStream toConvert) throws JAXBException {
+		return ProcessorConfigImpl.fromXml(toConvert);
+	}
+
+	public static final ItemProcessor createProcessor(final ProcessorConfig config) {
 		return ProcessorImpl.newProcessor(config);
 	}
-	
-    public static void resultToXml(final ProcessorResult toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-    	ProcessorResultImpl.toXml(toConvert, stream, prettyXml);
-    }
 
-    public static ProcessorResult resultFromXml(final InputStream toConvert)
-            throws JAXBException {
-    	return ProcessorResultImpl.fromXml(toConvert);
-    }
+	public static final StreamingProcessor createStreamingProcessor(final ProcessorConfig config) throws JAXBException {
+		return StreamingProcessorImpl.newInstance(createProcessor(config));
+	}
 
-    public static void taskResultToXml(final TaskResult toConvert,
-            final OutputStream stream, Boolean prettyXml) throws JAXBException {
-    	TaskResultImpl.toXml(toConvert, stream, prettyXml);
-    }
+	public static void resultToXml(final ProcessorResult toConvert, final OutputStream stream, Boolean prettyXml)
+			throws JAXBException {
+		ProcessorResultImpl.toXml(toConvert, stream, prettyXml);
+	}
 
-    public static TaskResult taskResultfromXml(final InputStream toConvert)
-            throws JAXBException {
-    	return TaskResultImpl.fromXml(toConvert);
-    }
+	public static ProcessorResult resultFromXml(final InputStream toConvert) throws JAXBException {
+		return ProcessorResultImpl.fromXml(toConvert);
+	}
+
+	public static void taskResultToXml(final TaskResult toConvert, final OutputStream stream, Boolean prettyXml)
+			throws JAXBException {
+		TaskResultImpl.toXml(toConvert, stream, prettyXml);
+	}
+
+	public static TaskResult taskResultfromXml(final InputStream toConvert) throws JAXBException {
+		return TaskResultImpl.fromXml(toConvert);
+	}
 
 }

--- a/core/src/main/java/org/verapdf/processor/StreamingProcessor.java
+++ b/core/src/main/java/org/verapdf/processor/StreamingProcessor.java
@@ -1,0 +1,30 @@
+/**
+ * 
+ */
+package org.verapdf.processor;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.List;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 2 Nov 2016:11:10:17
+ */
+
+public interface StreamingProcessor extends Processor {
+	public BatchSummary process(List<? extends File> toProcess, OutputStream dest) throws XMLStreamException, JAXBException;
+
+	public BatchSummary processDirectory(File toProcess, OutputStream dest, boolean recurse)
+			throws XMLStreamException, JAXBException;
+
+	public BatchSummary process(List<? extends File> toProcess, Writer dest) throws XMLStreamException, JAXBException;
+
+	public BatchSummary processDirectory(File toProcess, Writer dest, boolean recurse)
+			throws XMLStreamException, JAXBException;
+}

--- a/core/src/main/java/org/verapdf/processor/StreamingProcessorImpl.java
+++ b/core/src/main/java/org/verapdf/processor/StreamingProcessorImpl.java
@@ -1,0 +1,224 @@
+/**
+ * 
+ */
+package org.verapdf.processor;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.verapdf.ReleaseDetails;
+import org.verapdf.component.ComponentDetails;
+import org.verapdf.core.XmlSerialiser;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 2 Nov 2016:11:29:39
+ */
+
+public class StreamingProcessorImpl implements StreamingProcessor {
+	private final static int indentSize = 2;
+	private final static String encoding = "job";
+	private final static String xmlVersion = "1.0";
+	private final static String report = "report";
+	private final static String job = "job";
+	private final static String jobs = job + "s";
+	private final static String lineSepProp = "line.separator";
+	private final static String newline = System.getProperty(lineSepProp);
+	private final static String strmClose = "Exception closing result stream";
+	private static final Logger logger = Logger.getLogger(StreamingProcessorImpl.class.getCanonicalName());
+	private static XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
+	private final ItemProcessor processor;
+	private int indent = 0;
+	private XMLStreamWriter writer;
+
+	private StreamingProcessorImpl(ItemProcessor processor) {
+		this.processor = processor;
+	}
+
+	/**
+	 * @see org.verapdf.processor.Processor#getConfig()
+	 */
+	@Override
+	public ProcessorConfig getConfig() {
+		return this.processor.getConfig();
+	}
+
+	/**
+	 * @see org.verapdf.processor.Processor#getDependencies()
+	 */
+	@Override
+	public Collection<ReleaseDetails> getDependencies() {
+		return this.processor.getDependencies();
+	}
+
+	/**
+	 * @see org.verapdf.component.Component#getDetails()
+	 */
+	@Override
+	public ComponentDetails getDetails() {
+		return this.processor.getDetails();
+	}
+
+	@Override
+	public BatchSummary processDirectory(File toProcess, OutputStream dest, boolean recurse)
+			throws XMLStreamException, JAXBException {
+		Writer osw = new OutputStreamWriter(dest);
+		return processDirectory(toProcess, osw, recurse);
+	}
+
+	@Override
+	public BatchSummary processDirectory(File toProcess, Writer dest, boolean recurse)
+			throws XMLStreamException, JAXBException {
+		this.writer = outputFactory.createXMLStreamWriter(dest);
+		startDoc(this.writer);
+		this.processDirectory(toProcess, recurse);
+		endDoc(this.writer);
+		try {
+			this.writer.close();
+		} catch (XMLStreamException excep) {
+			logger.log(Level.INFO, strmClose, excep);
+		}
+		return null;
+	}
+
+	/**
+	 * @see org.verapdf.processor.StreamingProcessor#process(java.util.List,
+	 *      java.io.OutputStream)
+	 */
+	@Override
+	public BatchSummary process(List<? extends File> toProcess, OutputStream dest) throws XMLStreamException, JAXBException {
+		Writer osw = new OutputStreamWriter(dest);
+		return this.process(toProcess, osw);
+	}
+
+	@Override
+	public BatchSummary process(List<? extends File> toProcess, Writer dest) throws XMLStreamException, JAXBException {
+		this.writer = outputFactory.createXMLStreamWriter(dest);
+		startDoc(this.writer);
+		this.processItems(toProcess);
+		endDoc(this.writer);
+		try {
+			this.writer.close();
+		} catch (XMLStreamException excep) {
+			logger.log(Level.INFO, strmClose, excep);
+		}
+		return null;
+	}
+
+	static StreamingProcessor newInstance(ItemProcessor processor) {
+		return new StreamingProcessorImpl(processor);
+	}
+
+	private void processDirectory(File root, boolean recurse) throws XMLStreamException, JAXBException {
+		if (root == null || !root.isDirectory() || !root.canRead()) {
+			logger.log(Level.SEVERE, badItemMessage(root, true));
+		} else {
+			indentElement(jobs);
+			processDir(root, recurse);
+			outdentElement();
+		}
+	}
+
+	private void processDir(File root, boolean recurse) throws XMLStreamException, JAXBException {
+		for (File item : root.listFiles()) {
+			if (item.isDirectory() && !item.isHidden() && item.canRead()) {
+				processDir(item, recurse);
+			} else {
+				processItem(item);
+			}
+		}
+	}
+
+	private void processItems(List<? extends File> items) throws XMLStreamException, JAXBException {
+		indentElement(jobs);
+		for (File item : items) {
+			if (item == null || !item.isFile() || !item.canRead()) {
+				logger.log(Level.SEVERE, badItemMessage(item, false));
+			} else {
+				processItem(item);
+			}
+		}
+		outdentElement();
+	}
+
+	private void processItem(File item) throws XMLStreamException, JAXBException {
+		try {
+			indentElement(job);
+			newLine(this.writer, this.indent());
+			streamResult(this.processor.process(item), this.writer);
+		} catch (FileNotFoundException excep) {
+			// Should really never happen after defensive file check in process
+			// items
+			logger.log(Level.SEVERE, badItemMessage(item, false), excep);
+		}
+		newLine(this.writer, this.outdent());
+		outdentElement();
+	}
+
+	private static void streamResult(ProcessorResult result, XMLStreamWriter writer) throws JAXBException {
+		XmlSerialiser.toXml(result.getValidationResult(), writer, true, true);
+	}
+
+	private static String badItemMessage(File item, boolean isDir) {
+		String itemType = isDir ? "directory" : "file";
+		if (item == null)
+			return "Null " + itemType + " item passed for processing.";
+		final String rootMessage = "Couldn't process: " + item.getAbsolutePath() + " is not a ";
+		final String messageTrail = (item.canRead()) ? itemType + "." : "readable " + itemType + ".";
+		return rootMessage + messageTrail;
+	}
+
+	private static void startDoc(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeStartDocument(encoding, xmlVersion);
+		newLine(writer);
+		writer.writeStartElement(report);
+	}
+
+	private static void endDoc(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeEndElement();
+		newLine(writer);
+		writer.writeEndDocument();
+	}
+	
+	private static void newLine(XMLStreamWriter writer) throws XMLStreamException {
+		writer.writeCharacters(newline);
+	}
+
+	private static void newLine(XMLStreamWriter writer, int indent) throws XMLStreamException {
+		newLine(writer);
+		writer.writeCharacters(new String(new char[indent]).replace('\0', ' '));
+	}
+
+	private void indentElement(String eleName) throws XMLStreamException {
+		newLine(this.writer, this.indent());
+		this.writer.writeStartElement(eleName);
+	}
+
+	private void outdentElement() throws XMLStreamException {
+		this.writer.writeEndElement();
+		newLine(this.writer, this.outdent());
+	}
+
+	private int indent() {
+		return this.indent = this.indent + indentSize;
+	}
+
+	private int outdent() {
+		if (this.indent >= indentSize)
+			return this.indent = this.indent - indentSize;
+		return this.indent = 0;
+	}
+}

--- a/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
@@ -92,8 +92,8 @@ public class ValidationResultTest {
         Set<TestAssertion> assertions = new HashSet<>();
         assertions.add(ValidationResults.defaultAssertion());
         ValidationResult result = ValidationResults.resultFromValues(PDFAFlavour.PDFA_1_A, assertions);
-        String xmlRawResult = ValidationResults.resultToXml(result, Boolean.FALSE);
-        String xmlPrettyResult = ValidationResults.resultToXml(result, Boolean.TRUE);
+        String xmlRawResult = ValidationResults.resultToXml(result, false);
+        String xmlPrettyResult = ValidationResults.resultToXml(result, true);
         assertFalse(xmlRawResult.equals(xmlPrettyResult));
         ValidationResult fromRawXml = ValidationResults.fromXml(xmlRawResult);
         ValidationResult fromPrettyXml = ValidationResults.fromXml(xmlPrettyResult);
@@ -113,7 +113,7 @@ public class ValidationResultTest {
         ValidationResult result = ValidationResults.resultFromValues(PDFAFlavour.PDFA_1_A, assertions);
         File temp = Files.createTempFile("profile", "xml").toFile();
         try (OutputStream forXml = new FileOutputStream(temp)) {
-            ValidationResults.toXml(result, forXml, Boolean.TRUE);
+            ValidationResults.toXml(result, forXml, true, true);
         }
         try (InputStream readXml = new FileInputStream(temp)) {
             ValidationResult unmarshalledResult = ValidationResults


### PR DESCRIPTION
- added convenience method to ReleaseDetails to get the full details Collection;
- renamed existing processor interface to ItemProcessor;
- tweaked agressive exception warning for bad dates;
- tidied code formatting;
- xml serialiser now use primitives;
- added generic handler for JAXB types; and
- added new StreamingProcessor interface and implementation.