### PR TITLE
Fixed null in getType() in TaskResultImpl.

### DIFF
--- a/core/src/main/java/org/verapdf/processor/TaskResultImpl.java
+++ b/core/src/main/java/org/verapdf/processor/TaskResultImpl.java
@@ -71,8 +71,7 @@ class TaskResultImpl implements TaskResult {
 
 	@Override
 	public TaskType getType() {
-		// TODO Auto-generated method stub
-		return null;
+		return type;
 	}
 
 	@Override


### PR DESCRIPTION
Closes https://github.com/veraPDF/veraPDF-apps/issues/115.