### PR TITLE
Cleaned up code in AuditDuration

### DIFF
--- a/core/src/main/java/org/verapdf/component/AuditDuration.java
+++ b/core/src/main/java/org/verapdf/component/AuditDuration.java
@@ -5,24 +5,12 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @XmlJavaTypeAdapter(AuditDurationImpl.Adapter.class)
 public interface AuditDuration {
 
-	/**
-	 * @return the start
-	 */
-	public long getStart();
+	long getStart();
 
-	/**
-	 * @return the finish
-	 */
-	public long getFinish();
+	long getFinish();
 
-	/**
-	 * @return the finish
-	 */
-	public long getDifference();
+	long getDifference();
 
-	/**
-	 * @return the duration string
-	 */
-	public String getDuration();
+	String getDuration();
 
 }

--- a/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
+++ b/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
@@ -1,0 +1,19 @@
+package org.verapdf.component;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AuditDurationImplTest {
+
+    @Test
+    public void testGetStringDuration() {
+        long second = 1000;
+        long minute = 60 * second;
+        long hour = 60 * minute;
+        assertEquals("00:00:00:000", AuditDurationImpl.getStringDuration(0));
+        assertEquals("01:23:45:678", AuditDurationImpl.getStringDuration(
+                hour + 23 * minute + 45 * second + 678));
+    }
+
+}


### PR DESCRIPTION
* removed redundant Javadoc
* removed redundant "public" modifier
* replaced equals/hashCode with shorter code
* fixed message in IllegalArgumentException
* made getStringDuration code shorter
* added unit test

This re-adds what some consider magic numbers to the code. On second
thought, the numbers 60 and 1000 are not magic at all when used in time
calculations, therefore there is no need to represent them as named
constants.