### PR TITLE
FEAT - Pretty Print XML Reports

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,6 +64,17 @@
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>net.java.dev.stax-utils</groupId>
+        <artifactId>stax-utils</artifactId>
+        <version>20070216</version>
+        <exclusions>
+            <exclusion>
+                <groupId>com.bea.xml</groupId>
+                <artifactId>jsr173-ri</artifactId>
+            </exclusion>
+        </exclusions>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/core/src/main/java/org/verapdf/ReleaseDetails.java
+++ b/core/src/main/java/org/verapdf/ReleaseDetails.java
@@ -53,10 +53,10 @@ public final class ReleaseDetails {
 	public static final String PROPERTIES_EXT = "properties"; //$NON-NLS-1$
 	public static final String LIBRARY_DETAILS_RESOURCE = APPLICATION_PROPERTIES_ROOT + "library." + PROPERTIES_EXT; //$NON-NLS-1$
 
-	private static final String RAW_DATE_FORMAT = "${maven.build.timestamp.format}";
-	private static final String RIGHTS = "Developed and released by the veraPDF Consortium.\n"
-			+ "Funded by the PREFORMA project.\n" + "Released under the GNU General Public License v3\n"
-			+ "and the Mozilla Public License v2 or later.\n";
+	private static final String RAW_DATE_FORMAT = "${maven.build.timestamp.format}"; //$NON-NLS-1$
+	private static final String RIGHTS = "Developed and released by the veraPDF Consortium.\n" //$NON-NLS-1$
+			+ "Funded by the PREFORMA project.\n" + "Released under the GNU General Public License v3\n"  //$NON-NLS-1$//$NON-NLS-2$
+			+ "and the Mozilla Public License v2 or later.\n"; //$NON-NLS-1$
 
 	private static final ReleaseDetails DEFAULT = new ReleaseDetails();
 	private static final Map<String, ReleaseDetails> DETAILS = initDetailsMap();

--- a/core/src/main/java/org/verapdf/core/XmlSerialiser.java
+++ b/core/src/main/java/org/verapdf/core/XmlSerialiser.java
@@ -369,8 +369,8 @@ public final class XmlSerialiser {
 	 *            Collection that needs to be scanned
 	 * @return Classes found in the collection, including JAXBCollection.
 	 */
-	protected static <T> Class[] findTypes(Collection<T> c) {
-		Set<Class> types = new HashSet<>();
+	protected static <T> Class<?>[] findTypes(Collection<T> c) {
+		Set<Class<?>> types = new HashSet<>();
 		types.add(JAXBCollection.class);
 		for (T o : c) {
 			if (o != null) {

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -34,12 +34,12 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 public class ValidationResults {
-	private static final String NOT_NULL_MESSAGE = " cannot be null.";
-	private static final String FLAVOUR_NOT_NULL_MESSAGE = "Flavour " + NOT_NULL_MESSAGE;
-	private static final String ASSERTIONS_NOT_NULL_MESSAGE = "Assertions " + NOT_NULL_MESSAGE;
+	private static final String NOT_NULL_MESSAGE = " cannot be null."; //$NON-NLS-1$
+	private static final String FLAVOUR_NOT_NULL_MESSAGE = "Flavour " + NOT_NULL_MESSAGE; //$NON-NLS-1$
+	private static final String ASSERTIONS_NOT_NULL_MESSAGE = "Assertions " + NOT_NULL_MESSAGE; //$NON-NLS-1$
 
 	private ValidationResults() {
-		throw new AssertionError("Should never enter ValidationResults().");
+		throw new AssertionError("Should never enter ValidationResults()."); //$NON-NLS-1$
 	}
 
 	/**
@@ -196,7 +196,7 @@ public class ValidationResults {
 	 */
 	public static ValidationResult stripPassedTests(ValidationResult toStrip) {
 		if (toStrip == null)
-			throw new NullPointerException("toStrip can not be null.");
+			throw new NullPointerException("toStrip can not be null."); //$NON-NLS-1$
 		return ValidationResultImpl.stripPassedTests(toStrip);
 	}
 }

--- a/core/src/main/java/org/verapdf/processor/AbstractBatchHandler.java
+++ b/core/src/main/java/org/verapdf/processor/AbstractBatchHandler.java
@@ -45,7 +45,7 @@ public abstract class AbstractBatchHandler implements BatchProcessingHandler {
 	@Override
 	public void handleResult(ProcessorResult result) throws VeraPDFException {
 		if (result == null) {
-			throw new VeraPDFException("Arg result is null and can not be handled.");
+			throw new VeraPDFException("Arg result is null and can not be handled."); //$NON-NLS-1$
 		}
 		resultStart(result);
 		processTasks(result);

--- a/core/src/main/java/org/verapdf/processor/AbstractXmlHandler.java
+++ b/core/src/main/java/org/verapdf/processor/AbstractXmlHandler.java
@@ -1,22 +1,16 @@
 /**
  * This file is part of veraPDF Library core, a module of the veraPDF project.
- * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
- * All rights reserved.
- *
- * veraPDF Library core is free software: you can redistribute it and/or modify
- * it under the terms of either:
- *
- * The GNU General public license GPLv3+.
- * You should have received a copy of the GNU General Public License
- * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
- * tree.  If not, see http://www.gnu.org/licenses/ or
- * https://www.gnu.org/licenses/gpl-3.0.en.html.
- *
- * The Mozilla Public License MPLv2+.
- * You should have received a copy of the Mozilla Public License along with
- * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
- * If a copy of the MPL was not distributed with this file, you can obtain one at
- * http://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org> All rights
+ * reserved. veraPDF Library core is free software: you can redistribute it
+ * and/or modify it under the terms of either: The GNU General public license
+ * GPLv3+. You should have received a copy of the GNU General Public License
+ * along with veraPDF Library core as the LICENSE.GPL file in the root of the
+ * source tree. If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html. The Mozilla Public License
+ * MPLv2+. You should have received a copy of the Mozilla Public License along
+ * with veraPDF Library core as the LICENSE.MPL file in the root of the source
+ * tree. If a copy of the MPL was not distributed with this file, you can obtain
+ * one at http://mozilla.org/MPL/2.0/.
  */
 /**
  * 
@@ -24,6 +18,9 @@
 package org.verapdf.processor;
 
 import org.verapdf.core.VeraPDFException;
+import org.verapdf.core.XmlSerialiser;
+
+import javanet.staxutils.IndentingXMLStreamWriter;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.stream.XMLOutputFactory;
@@ -41,43 +38,47 @@ import java.util.logging.Logger;
 
 public abstract class AbstractXmlHandler extends AbstractBatchHandler {
 	private static final Logger logger = Logger.getLogger(AbstractXmlHandler.class.getCanonicalName());
-	protected final static String strmExcpMessTmpl = "XmlStreamException caught when %s output writer.";
-	protected final static String unmarshalErrMessage = "Unmarshalling exception when streaming %s.";
-	private final static String encoding = "utf-8";
-	private final static String xmlVersion = "1.0";
-	private final static String lineSepProp = "line.separator";
+	protected final static String strmExcpMessTmpl = "XmlStreamException caught when %s output writer."; //$NON-NLS-1$
+	protected final static String unmarshalErrMessage = "Unmarshalling exception when streaming %s."; //$NON-NLS-1$
+	protected final static String writingMessage = "writing"; //$NON-NLS-1$
+	private final static String encoding = "utf-8"; //$NON-NLS-1$
+	private final static String xmlVersion = "1.0"; //$NON-NLS-1$
+	private final static String lineSepProp = "line.separator"; //$NON-NLS-1$
 	private final static String newline = System.getProperty(lineSepProp);
 	private static XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
 
 	protected XMLStreamWriter writer;
-	private final int indentSize;
-	private int indent = 0;
 
 	protected AbstractXmlHandler(final Writer dest) throws VeraPDFException {
-		this(dest, 2);
-	}
-
-	/**
-	 * 
-	 */
-	protected AbstractXmlHandler(final Writer dest, final int indentSize) throws VeraPDFException {
 		super();
-		this.indentSize = indentSize;
 		try {
-			this.writer = outputFactory.createXMLStreamWriter(dest);
+			this.writer = new IndentingXMLStreamWriter(outputFactory.createXMLStreamWriter(dest));
 		} catch (XMLStreamException excep) {
-			throw wrapStreamException(excep, "initialising");
+			throw wrapStreamException(excep, "initialising"); //$NON-NLS-1$
 		}
 	}
 
-	protected int indent() {
-		return this.indent = this.indent + indentSize;
+	protected <T> void serialseElement(T obj, String eleName, boolean format, boolean fragment)
+			throws VeraPDFException {
+		try {
+			XmlSerialiser.toXml(obj, this.writer, format, fragment);
+			this.writer.flush();
+		} catch (JAXBException excep) {
+			logger.log(Level.WARNING, String.format(unmarshalErrMessage, eleName), excep);
+			throw wrapMarshallException(excep, eleName);
+		} catch (XMLStreamException excep) {
+			logger.log(Level.WARNING, String.format(strmExcpMessTmpl, writingMessage), excep);
+			throw wrapStreamException(excep, eleName);
+		}
 	}
 
-	protected int outdent() {
-		if (this.indent >= indentSize)
-			return this.indent = this.indent - indentSize;
-		return this.indent = 0;
+	@Override
+	public void close() {
+		try {
+			this.writer.close();
+		} catch (XMLStreamException excep) {
+			logger.log(Level.INFO, String.format(strmExcpMessTmpl, "closing"), excep); //$NON-NLS-1$
+		}
 	}
 
 	protected static void startDoc(XMLStreamWriter writer) throws XMLStreamException {
@@ -85,34 +86,20 @@ public abstract class AbstractXmlHandler extends AbstractBatchHandler {
 	}
 
 	protected static void endDoc(XMLStreamWriter writer) throws XMLStreamException {
+		newLine(writer);
 		writer.writeEndDocument();
-	}
-
-	protected void indentElement(String eleName) throws XMLStreamException {
-		newLine(this.writer, this.indent());
-		this.writer.writeStartElement(eleName);
 	}
 
 	protected void addAttribute(String name, String value) throws XMLStreamException {
 		this.writer.writeAttribute(name, value);
 	}
 
-	protected void outdentElement() throws XMLStreamException {
-		this.writer.writeEndElement();
-		newLine(this.writer, this.outdent());
-	}
-
 	protected static void newLine(XMLStreamWriter writer) throws XMLStreamException {
 		writer.writeCharacters(newline);
 	}
 
-	protected static void newLine(XMLStreamWriter writer, int indent) throws XMLStreamException {
-		newLine(writer);
-		writer.writeCharacters(new String(new char[indent]).replace('\0', ' '));
-	}
-
 	protected static VeraPDFException wrapStreamException(final XMLStreamException excep) {
-		return wrapStreamException(excep, "writing to");
+		return wrapStreamException(excep, "writing to"); //$NON-NLS-1$
 	}
 
 	protected static VeraPDFException wrapStreamException(final XMLStreamException excep, final String verbPart) {
@@ -123,12 +110,4 @@ public abstract class AbstractXmlHandler extends AbstractBatchHandler {
 		return new VeraPDFException(String.format(unmarshalErrMessage, typePart), excep);
 	}
 
-	@Override
-	public void close() {
-		try {
-			this.writer.close();
-		} catch (XMLStreamException excep) {
-			logger.log(Level.INFO, String.format(strmExcpMessTmpl, "closing"), excep);
-		}
-	}
 }

--- a/core/src/main/java/org/verapdf/processor/ProcessorFactory.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorFactory.java
@@ -105,11 +105,6 @@ public final class ProcessorFactory {
 		return RawResultHandler.newInstance(dest);
 	}
 
-	public static final BatchProcessingHandler rawResultHandler(final Writer dest, final int indentSize)
-			throws VeraPDFException {
-		return RawResultHandler.newInstance(dest, indentSize);
-	}
-
 	public static final BatchProcessingHandler getHandler(FormatOption option, boolean isVerbose, int maxFailedChecksPerRule, boolean logPassed)
 			throws VeraPDFException {
 		return getHandler(option, isVerbose, System.out, maxFailedChecksPerRule, logPassed);
@@ -118,9 +113,9 @@ public final class ProcessorFactory {
 	public static final BatchProcessingHandler getHandler(FormatOption option, boolean isVerbose,
 			OutputStream reportStream, int maxFailedChecksPerRule, boolean logPassed) throws VeraPDFException {
 		if (option == null)
-			throw new IllegalArgumentException("Arg option can not be null");
+			throw new IllegalArgumentException("Arg option can not be null"); //$NON-NLS-1$
 		if (reportStream == null)
-			throw new IllegalArgumentException("Arg reportStream can not be null");
+			throw new IllegalArgumentException("Arg reportStream can not be null"); //$NON-NLS-1$
 
 		switch (option) {
 		case TEXT:
@@ -130,7 +125,7 @@ public final class ProcessorFactory {
 		case MRR:
 			return MrrHandler.newInstance(new PrintWriter(reportStream), logPassed, maxFailedChecksPerRule);
 		default: // should not be reached
-			throw new VeraPDFException("Unknown report format option: " + option);
+			throw new VeraPDFException("Unknown report format option: " + option); //$NON-NLS-1$
 		}
 	}
 

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationReportImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationReportImpl.java
@@ -46,7 +46,7 @@ final class ValidationReportImpl implements ValidationReport {
 	private final boolean isCompliant;
 
 	private ValidationReportImpl() {
-		this(ValidationDetailsImpl.defaultInstance(), "Unknown Profile", "Statement", false);
+		this(ValidationDetailsImpl.defaultInstance(), "Unknown Profile", "Statement", false); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	private ValidationReportImpl(final ValidationDetails details, final String profileName, final String statement,


### PR DESCRIPTION
- replaced `XMLStreamWriter` with `IndentingXMLStreamWriter` from `stax-utils`;
- purged some externalised String warnings with `//$NON-NLS-1$`;
- fixed unparameterised Class warning in `XMLSerialiser`;
- removed old indent hack from `BatchFileProcessor`;
- factored all Strings into single constants; and
- refactored element serialisation and exception handling.
Closes #119