### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/LICENSE-HEADERS.md
+++ b/LICENSE-HEADERS.md
@@ -2,11 +2,11 @@ License Headers for Source Code
 ===============================
 Introduction
 ------------
-###Audience
+### Audience
  - veraPDF developers wanting to add a license header to the source code; and
  - anyone interested in knowing how our release process works.
 
-###Pre-requisites
+### Pre-requisites
 If you're still reading you'll also need an understanding and some experience using [Git](https://git-scm.com) and [Maven](https://maven.apache.org/).
 
 License Headers
@@ -25,7 +25,7 @@ The following worked example shows how to add the license headers to the 0.8 rel
  - create a temporary Git branch with MPL headers; and
  - use Git to create a zip and tar archive of the headed code.
 
-###Getting to the release branch
+### Getting to the release branch
 You should use the latest version of the `release-0.8` branch of the project. In the following example we'll start from scratch and assume:
  - you're using a bash shell; and
  - the `git remote` name for the repo used is `origin`.
@@ -55,7 +55,7 @@ outputs:
 
     nothing to commit, working directory clean
 
-###Creating a GPL source headed branch
+### Creating a GPL source headed branch
 From the release-0.8 branch create a new branch for the licensed source files:
 
     git checkout -b release-0.8-gpl origin/release-0.8
@@ -69,7 +69,7 @@ The Maven POM holds profiles for both of the license headers, we simply invoke w
 
 Now to create the MPL headed branch.
 
-###Creating an MPL source headed branch
+### Creating an MPL source headed branch
 From the release-0.8 branch create a new branch for the licensed source files:
 
     git checkout -b release-0.8-mpl origin/release-0.8
@@ -81,7 +81,7 @@ Again we invoke Maven, this time with the profile for the MPL header, test the c
     git add .
     git commit -m "Added MPL source headers."
 
-###Creating the source archives
+### Creating the source archives
 We can now use Git to create zip or tar source archives from our headed branches. To create a compressed tarball called `veraPDF-0.8-gpl.tar.gz` from our GPL headed branch `release-0.8-gpl` in the local directory:
 
     git archive --format=tar release-0.8-gpl | gzip > veraPDF-0.8-gpl.tar.gz

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In order to use the GUI you'll need:
  * Java 7, which can be downloaded [from Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html), or for Linux users [OpenJDK](http://openjdk.java.net/install/index.html).
 
 ### veraPDF GUI
-####Download release version
+#### Download release version
 You can download a Java-based installer for the latest veraPDF GUI release [from our download site](http://downloads.verapdf.org/rel/verapdf-installer.zip). The current installation process requires Java 1.7 to be pre-installed.
 
 #### Download latest development version
@@ -72,7 +72,7 @@ Life will be easier if you also use [Git](https://git-scm.com/) to obtain and ma
 
 ### Building veraPDF
 First you'll need to obtain a version of the veraPDF-library source code. You can compile either the latest relase version or the latest development source.
-####Downloading the latest release source
+#### Downloading the latest release source
 Use Git to clone the repository and ensure that the `master` branch is checked out:
 ```
 git clone https://github.com/veraPDF/veraPDF-library

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,19 +2,19 @@ Release Process
 ===============
 Introduction
 ------------
-###Audience
+### Audience
  - veraPDF development staff looking to release a new version;
  - anyone interested in knowing how our release process works; and
  - anyone who wants to change the version number or re-package our software.
 
-###Pre-requisites
+### Pre-requisites
 If you're still reading you'll also need an understanding and some experience using [Git](https://git-scm.com) and [Maven](https://maven.apache.org/). A quick brush up on [Semantic Versioning](http://semver.org/) and a typical [Git branching workflow](http://nvie.com/posts/a-successful-git-branching-model/) and we're ready to go.
 
 Releasing
 ---------
 The veraPDF software projects use the `MINOR` version number to indicate the development status of a particular version. An even number signifies a release version while an odd numbers are assigned to development prototypes. We increment the `MINOR` version number twice at each release milestone. The first increment is from the current odd numbered development version number to the new even release version.
 
-###Getting to integration
+### Getting to integration
 You should use the latest version of the `integration` branch of the project. In the following example we'll start from scratch and assume:
  - we're releasing `0.6.x` from development version `0.5.x`
  - you're using a bash shell; and
@@ -45,7 +45,7 @@ outputs:
 
     nothing to commit, working directory clean
 
-###Bumping minor
+### Bumping minor
 We bump the `MINOR` version on integration from `5` to `6` using Maven to set the version:
 
     mvn versions:set -DnewVersion=0.6.0
@@ -81,7 +81,7 @@ or issuing:
 
 will show the version numbers in the POM.
 
-###Create a release branch
+### Create a release branch
 If the version has been set properly then add the changes to Git and create a release branch:
 
     git add .
@@ -89,7 +89,7 @@ If the version has been set properly then add the changes to Git and create a re
     git checkout -b release-0.6
     git push --set-upstream origin release-0.6
 
-###Bump minor for integration to 0.7
+### Bump minor for integration to 0.7
 We now need to move the minor version number on the `integration` branch to 0.7 for future development:
 
     git checkout integration


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
