### PR TITLE
FIX - Audit Duration Reporting

### DIFF
--- a/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
+++ b/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
@@ -128,14 +128,20 @@ public final class AuditDurationImpl implements AuditDuration {
 		}
 	}
 
-	public static long sumDuration(Collection<AuditDuration> durations) {
-		long res = 0;
+	public static AuditDuration sumDuration(Collection<AuditDuration> durations) {
+		long start = 0L;
+		long finish = 0L;
 		if (durations != null) {
 			for (AuditDuration duration : durations) {
-				res += duration.getDifference();
+				if (start == 0 || duration.getStart() < start) {
+					start = duration.getStart();
+				}
+				if (duration.getFinish() > finish) {
+					finish = duration.getFinish();
+				}
 			}
 		}
-		return res;
+		return fromValues(start, finish);
 	}
 
 	static class Adapter extends XmlAdapter<AuditDurationImpl, AuditDuration> {

--- a/core/src/main/java/org/verapdf/features/objects/Feature.java
+++ b/core/src/main/java/org/verapdf/features/objects/Feature.java
@@ -20,13 +20,23 @@
  */
 package org.verapdf.features.objects;
 
-import org.verapdf.policy.SchematronOperation;
+import static org.verapdf.policy.SchematronOperation.CONTAINS;
+import static org.verapdf.policy.SchematronOperation.ENDS_WITH;
+import static org.verapdf.policy.SchematronOperation.IS_EQUAL;
+import static org.verapdf.policy.SchematronOperation.IS_FALSE;
+import static org.verapdf.policy.SchematronOperation.IS_GREATER;
+import static org.verapdf.policy.SchematronOperation.IS_GREATER_OR_EQUAL;
+import static org.verapdf.policy.SchematronOperation.IS_LESS;
+import static org.verapdf.policy.SchematronOperation.IS_LESS_OR_EQUAL;
+import static org.verapdf.policy.SchematronOperation.IS_TRUE;
+import static org.verapdf.policy.SchematronOperation.NOT_EQUAL;
+import static org.verapdf.policy.SchematronOperation.NOT_PRESENT;
+import static org.verapdf.policy.SchematronOperation.PRESENT;
+import static org.verapdf.policy.SchematronOperation.STARTS_WITH;
 
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Set;
 
-import static org.verapdf.policy.SchematronOperation.*;
+import org.verapdf.policy.SchematronOperation;
 
 /**
  * @author Maksim Bezrukov
@@ -45,15 +55,15 @@ public class Feature {
 
 
 	public String getFeatureName() {
-		return featureName;
+		return this.featureName;
 	}
 
 	public String getFeatureXPath() {
-		return featureXPath;
+		return this.featureXPath;
 	}
 
 	public FeatureType getFeatureType() {
-		return featureType;
+		return this.featureType;
 	}
 
 	public enum FeatureType {
@@ -67,7 +77,7 @@ public class Feature {
 		private EnumSet<SchematronOperation> legalOperations;
 
 		FeatureType(SchematronOperation op, SchematronOperation... operations) {
-			legalOperations = EnumSet.of(op, operations);
+			this.legalOperations = EnumSet.of(op, operations);
 		}
 
 		public EnumSet<SchematronOperation> getLegalOperations() {

--- a/core/src/main/java/org/verapdf/features/objects/FeaturesObject.java
+++ b/core/src/main/java/org/verapdf/features/objects/FeaturesObject.java
@@ -45,7 +45,7 @@ public abstract class FeaturesObject {
 	}
 
 	public void registerNewError(String error) {
-		errors.add(error);
+		this.errors.add(error);
 	}
 
 	/**
@@ -64,9 +64,9 @@ public abstract class FeaturesObject {
 		this.errors.clear();
 		if (this.adapter.isPDFObjectPresent()) {
 			FeatureTreeNode root = collectFeatures();
-			this.errors.addAll(adapter.getErrors());
-			if (!errors.isEmpty()) {
-				for (String error : errors) {
+			this.errors.addAll(this.adapter.getErrors());
+			if (!this.errors.isEmpty()) {
+				for (String error : this.errors) {
 					ErrorsHelper.addErrorIntoCollection(collection, root, error);
 				}
 			}
@@ -85,24 +85,24 @@ public abstract class FeaturesObject {
 
 	protected static String generateVariableXPath(String... node) {
 		if (node == null || node.length == 0) {
-			throw new IllegalArgumentException("There should be at least one node");
+			throw new IllegalArgumentException("There should be at least one node"); //$NON-NLS-1$
 		}
 		StringBuilder builder = new StringBuilder(node[0]);
 		for (int i = 1; i < node.length; ++i) {
-			builder.append("/").append(node[i]);
+			builder.append("/").append(node[i]); //$NON-NLS-1$
 		}
 		return builder.toString();
 	}
 
 	protected static String generateAttributeXPath(String... node) {
 		if (node == null || node.length < 2) {
-			throw new IllegalArgumentException("There should be at least two nodes for attribute path");
+			throw new IllegalArgumentException("There should be at least two nodes for attribute path"); //$NON-NLS-1$
 		}
 		StringBuilder builder = new StringBuilder(node[0]);
 		for (int i = 1; i < node.length - 1; ++i) {
-			builder.append("/").append(node[i]);
+			builder.append("/").append(node[i]); //$NON-NLS-1$
 		}
-		builder.append("/@").append(node[node.length - 1]);
+		builder.append("/@").append(node[node.length - 1]); //$NON-NLS-1$
 		return builder.toString();
 	}
 }

--- a/core/src/main/java/org/verapdf/model/tools/xmp/validators/URITypeValidator.java
+++ b/core/src/main/java/org/verapdf/model/tools/xmp/validators/URITypeValidator.java
@@ -22,21 +22,15 @@ package org.verapdf.model.tools.xmp.validators;
 
 import com.adobe.xmp.impl.VeraPDFXMPNode;
 
-import java.util.logging.Logger;
-
 /**
  * @author Maksim Bezrukov
  */
 public class URITypeValidator implements TypeValidator {
 
-    private static final Logger LOGGER = Logger
-            .getLogger(URITypeValidator.class.getName());
-
-    @SuppressWarnings("unused")
     @Override
     public boolean isCorresponding(VeraPDFXMPNode node) {
         if (node == null) {
-            throw new IllegalArgumentException("Argument node can not be null.");
+            throw new IllegalArgumentException("Argument node can not be null."); //$NON-NLS-1$
         }
         // was changed to text validation after discussion with TWG
 //        try {

--- a/core/src/main/java/org/verapdf/processor/MrrHandler.java
+++ b/core/src/main/java/org/verapdf/processor/MrrHandler.java
@@ -28,8 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import javax.xml.bind.JAXBException;
 import javax.xml.stream.XMLStreamException;
@@ -54,7 +52,6 @@ import org.verapdf.report.FeaturesReport;
  */
 
 final class MrrHandler extends AbstractXmlHandler {
-	private final static Logger logger = Logger.getLogger(MrrHandler.class.getCanonicalName());
     private final static String STATEMENT_PREFIX = "PDF file is ";
     private final static String NOT_INSERT = "not ";
     private final static String STATEMENT_SUFFIX = "compliant with Validation Profile requirements.";
@@ -181,12 +178,10 @@ final class MrrHandler extends AbstractXmlHandler {
 
 	@Override
 	void resultEnd(ProcessorResult result) throws VeraPDFException {
+		AuditDuration duration = AuditDurationImpl.sumDuration(getDurations(result));
+		this.serialseElement(duration, procTimeEleName, true, true);
 		try {
 			// End job element
-			this.writer.writeStartElement(procTimeEleName);
-			long resTime = AuditDurationImpl.sumDuration(getDurations(result));
-			this.writer.writeCharacters(AuditDurationImpl.getStringDuration(resTime));
-			this.writer.writeEndElement();
 			this.writer.writeEndElement();
 			this.writer.flush();
 		} catch (XMLStreamException excep) {

--- a/core/src/main/java/org/verapdf/processor/SingleLineResultHandler.java
+++ b/core/src/main/java/org/verapdf/processor/SingleLineResultHandler.java
@@ -35,12 +35,12 @@ import org.verapdf.report.FeaturesReport;
  * @author Sergey Shemyakov
  */
 class SingleLineResultHandler extends AbstractBatchHandler {
-	private static final String pass = "PASS ";
-	private static final String fail = "FAIL ";
-	private static final String ioExcepMess = "IOException caught when writing to output stream";
+	private static final String pass = "PASS "; //$NON-NLS-1$
+	private static final String fail = "FAIL "; //$NON-NLS-1$
+	private static final String ioExcepMess = "IOException caught when writing to output stream"; //$NON-NLS-1$
 	private static final String parseExcepMessTmpl = "%s does not appear to be a valid PDF file and could not be parsed.";
 	private static final String pdfEncryptMessTmpl = "%s appears to be an encrypted PDF file and could not be processed.";
-	private static final String ruleMessTmpl = "  %s%s-%d\n";
+	private static final String ruleMessTmpl = "  %s%s-%d\n"; //$NON-NLS-1$
 	private OutputStream outputStream;
 	private final boolean isVerbose;
 	private final boolean logSuccess;
@@ -97,7 +97,7 @@ class SingleLineResultHandler extends AbstractBatchHandler {
 	@Override
 	void validationSuccess(final TaskResult taskResult, final ValidationResult validationResult)
 			throws VeraPDFException {
-		String reportSummary = (validationResult.isCompliant() ? pass : fail) + this.item.getName() + "\n";
+		String reportSummary = (validationResult.isCompliant() ? pass : fail) + this.item.getName() + "\n"; //$NON-NLS-1$
 		try {
 			this.outputStream.write(reportSummary.getBytes());
 			if (this.isVerbose) {
@@ -110,7 +110,7 @@ class SingleLineResultHandler extends AbstractBatchHandler {
 
 	@Override
 	void validationFailure(final TaskResult taskResult) throws VeraPDFException {
-		String reportSummary = "ERROR " + this.item.getName() + " " + taskResult.getType().fullName() + "\n";
+		String reportSummary = "ERROR " + this.item.getName() + " " + taskResult.getType().fullName() + "\n"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		try {
 			this.outputStream.write(reportSummary.getBytes());
 		} catch (IOException excep) {
@@ -161,7 +161,7 @@ class SingleLineResultHandler extends AbstractBatchHandler {
 		for (TestAssertion assertion : validationResult.getTestAssertions()) {
 			if (assertion.getStatus() == TestAssertion.Status.FAILED) {
 				failedRules.add(assertion.getRuleId());
-			} else if (this.isVerbose) {
+			} else if (this.logSuccess) {
 				passedRules.add(assertion.getRuleId());
 			}
 		}

--- a/core/src/main/java/org/verapdf/processor/plugins/PluginConfig.java
+++ b/core/src/main/java/org/verapdf/processor/plugins/PluginConfig.java
@@ -20,19 +20,19 @@
  */
 package org.verapdf.processor.plugins;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * @author Maksim Bezrukov
@@ -65,7 +65,7 @@ public class PluginConfig {
 	}
 
 	private PluginConfig() {
-		this(false, "", "", "", FileSystems.getDefault().getPath(""), Collections.<Attribute>emptyList());
+		this(false, "", "", "", FileSystems.getDefault().getPath(""), Collections.<Attribute>emptyList());  //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$//$NON-NLS-4$
 	}
 
 	public static PluginConfig fromValues(boolean enabled, String name, String version, String description, Path pluginFolder, List<Attribute> attributes) {

--- a/core/src/main/java/org/verapdf/report/FeaturesNode.java
+++ b/core/src/main/java/org/verapdf/report/FeaturesNode.java
@@ -116,7 +116,7 @@ public class FeaturesNode {
 
 	static FeaturesNode fromValues(FeatureTreeNode node, FeatureExtractionResult collection) {
 		if (node == null) {
-			throw new IllegalArgumentException("Argument node cannot be null");
+			throw new IllegalArgumentException("Argument node cannot be null"); //$NON-NLS-1$
 		}
 
 		Map<QName, Object> qAttributes = new HashMap<>();

--- a/core/src/main/java/org/verapdf/report/FeaturesReport.java
+++ b/core/src/main/java/org/verapdf/report/FeaturesReport.java
@@ -35,7 +35,7 @@ import org.verapdf.features.tools.FeatureTreeNode;
 @XmlRootElement(name="featuresReport")
 public class FeaturesReport {
 
-	private final static String ERROR_STATUS = "Could not finish features collecting due to unexpected error.";
+	private final static String ERROR_STATUS = "Could not finish features collecting due to unexpected error."; //$NON-NLS-1$
 
 	@XmlElement
 	private final String status;

--- a/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
+++ b/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
@@ -1,19 +1,76 @@
 package org.verapdf.component;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 public class AuditDurationImplTest {
+	/**
+	 * Test method for
+	 * {@link org.verapdf.component.AuditDurationImpl#hashCode()}.
+	 */
+	@Test
+	public void testHashCodeAndEquals() {
+		EqualsVerifier.forClass(AuditDurationImpl.class).verify();
+	}
 
-    @Test
-    public void testGetStringDuration() {
-        long second = 1000;
-        long minute = 60 * second;
-        long hour = 60 * minute;
-        assertEquals("00:00:00:000", AuditDurationImpl.getStringDuration(0));
-        assertEquals("01:23:45:678", AuditDurationImpl.getStringDuration(
-                hour + 23 * minute + 45 * second + 678));
-    }
+	@Test
+	public void testDefaultInstance() {
+		AuditDuration defaultInstance = AuditDurationImpl.defaultInstance();
+		assertTrue(defaultInstance == AuditDurationImpl.defaultInstance());
+	}
 
+	@Test(expected=IllegalArgumentException.class)
+	public void testFromValuesSubZeroStart() {
+		AuditDurationImpl.fromValues(-10, 0);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFromValuesSubZeroFinish() {
+		AuditDurationImpl.fromValues(0, -15);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testFromValuesHorseBeforeCart() {
+		AuditDurationImpl.fromValues(250000, 200000);
+	}
+
+	@Test
+	public void testGetStringDuration() {
+		long second = 1000;
+		long minute = 60 * second;
+		long hour = 60 * minute;
+		assertEquals("00:00:00:000", AuditDurationImpl.getStringDuration(0));
+		assertEquals("01:23:45:678", AuditDurationImpl.getStringDuration(hour + 23 * minute + 45 * second + 678));
+	}
+
+	@Test
+	public void testSumNulllDurations() {
+		assertEquals(AuditDurationImpl.defaultInstance(), AuditDurationImpl.sumDuration(null));
+	}
+
+	@Test
+	public void testSumEqualDurations() {
+		AuditDuration first = AuditDurationImpl.fromValues(10000, 25000);
+		AuditDuration second = AuditDurationImpl.fromValues(10000, 25000);
+		AuditDuration[] durations = {first, second};
+		assertEquals(first, AuditDurationImpl.sumDuration(Arrays.asList(durations)));
+		assertEquals(second, AuditDurationImpl.sumDuration(Arrays.asList(durations)));
+	}
+
+	@Test
+	public void testSumOverlappingDurations() {
+		AuditDuration first = AuditDurationImpl.fromValues(14000, 25000);
+		AuditDuration second = AuditDurationImpl.fromValues(15000, 30000);
+		AuditDuration third = AuditDurationImpl.fromValues(12000, 35000);
+		AuditDuration fourth = AuditDurationImpl.fromValues(10000, 27000);
+		AuditDuration expected = AuditDurationImpl.fromValues(10000, 35000);
+		AuditDuration[] durations = {first, second, third, fourth};
+		assertEquals(expected, AuditDurationImpl.sumDuration(Arrays.asList(durations)));
+	}
 }


### PR DESCRIPTION
Closes #689 
- jobs now report full duration details, not just string representation;
- AuditDurationImpl sumDuration method now returns an AuditDuration;
- more unit tests for AuditDuration;
- tidied compiler warnings;
- suppressed externalised string warnings; and
- removed unused code.