### PR TITLE
FIX - XML Report Clarity

### DIFF
--- a/core/src/main/java/org/verapdf/processor/AbstractBatchHandler.java
+++ b/core/src/main/java/org/verapdf/processor/AbstractBatchHandler.java
@@ -68,7 +68,7 @@ public abstract class AbstractBatchHandler implements BatchProcessingHandler {
 			case PARSE:
 				if (taskResult.isSuccess())
 					parsingSuccess(taskResult);
-				else if (!result.isValidPdf())
+				else if (!result.isPdf())
 					parsingFailure(taskResult);
 				else
 					pdfEncrypted(taskResult);

--- a/core/src/main/java/org/verapdf/processor/AbstractBatchProcessor.java
+++ b/core/src/main/java/org/verapdf/processor/AbstractBatchProcessor.java
@@ -108,7 +108,7 @@ public abstract class AbstractBatchProcessor implements BatchProcessor {
 	protected abstract void processList(final List<? extends File> toProcess) throws VeraPDFException;
 
 	private void initialise(final BatchProcessingHandler resultHandler) {
-		this.summariser = new ProcessorFactory.BatchSummariser();
+		this.summariser = new ProcessorFactory.BatchSummariser(this.getConfig());
 		this.handler = resultHandler;
 	}
 

--- a/core/src/main/java/org/verapdf/processor/ProcessorResult.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorResult.java
@@ -84,7 +84,7 @@ public interface ProcessorResult {
 	 * @return true if the parsed file was a valid PDF, false if the PDF parser
 	 *         failed to parse the document and couldn't continue to process it.
 	 */
-	public boolean isValidPdf();
+	public boolean isPdf();
 
 	/**
 	 * @return true if the parser detected that the PDF was encrypted and could

--- a/core/src/main/java/org/verapdf/processor/ProcessorResultImpl.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorResultImpl.java
@@ -49,7 +49,7 @@ import org.verapdf.report.FeaturesReport;
 class ProcessorResultImpl implements ProcessorResult {
 	private final static ProcessorResult defaultInstance = new ProcessorResultImpl();
 	@XmlAttribute
-	private final boolean isValidPdf;
+	private final boolean isPdf;
 	@XmlAttribute
 	private final boolean isEncryptedPdf;
 	@XmlElement
@@ -85,12 +85,12 @@ class ProcessorResultImpl implements ProcessorResult {
 		this(details, true, false, results, validationResult, featuresResult, fixerResult);
 	}
 
-	private ProcessorResultImpl(final ItemDetails details, final boolean isValidPdf, final boolean isEncrypted,
+	private ProcessorResultImpl(final ItemDetails details, final boolean isPdf, final boolean isEncrypted,
 			final EnumMap<TaskType, TaskResult> results, final ValidationResult validationResult,
 			final FeatureExtractionResult featuresResult, final MetadataFixerResult fixerResult) {
 		super();
 		this.itemDetails = details;
-		this.isValidPdf = isValidPdf;
+		this.isPdf = isPdf;
 		this.isEncryptedPdf = isEncrypted;
 		this.taskResults = results;
 		this.validationResult = validationResult;
@@ -163,8 +163,8 @@ class ProcessorResultImpl implements ProcessorResult {
 	}
 
 	@Override
-	public boolean isValidPdf() {
-		return this.isValidPdf;
+	public boolean isPdf() {
+		return this.isPdf;
 	}
 
 	@Override

--- a/core/src/main/java/org/verapdf/processor/reports/AbstractBatchJobSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/AbstractBatchJobSummary.java
@@ -1,0 +1,27 @@
+package org.verapdf.processor.reports;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlValue;
+
+public abstract class AbstractBatchJobSummary implements BatchJobSummary {
+	@XmlValue
+	protected final int totalJobs;
+	@XmlAttribute
+	protected final int failedJobs;
+
+	protected AbstractBatchJobSummary() {
+		this(0, 0);
+	}
+
+	protected AbstractBatchJobSummary(final int totalJobs, final int failedJobs) {
+		super();
+		assert (totalJobs >= 0 && failedJobs >= 0 && totalJobs >= failedJobs);
+		this.failedJobs = failedJobs;
+		this.totalJobs = totalJobs;
+	}
+	
+	@Override
+	public int getSuccessfulJobCount() {
+		return this.totalJobs - this.failedJobs;
+	}
+}

--- a/core/src/main/java/org/verapdf/processor/reports/BatchJobSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/BatchJobSummary.java
@@ -1,0 +1,27 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+/**
+ * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ *
+ * @version 0.1
+ * 
+ * Created 18 Apr 2017:18:24:01
+ */
+
+public interface BatchJobSummary {
+	/**
+	 * @return the number of jobs that failed to execute due to an exception.
+	 */
+	int getFailedJobCount();
+
+	/**
+	 * @return the total number of validation jobs in the batch.
+	 */
+	int getTotalJobCount();
+	
+	int getSuccessfulJobCount();
+}

--- a/core/src/main/java/org/verapdf/processor/reports/BatchSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/BatchSummary.java
@@ -34,38 +34,19 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @XmlJavaTypeAdapter(BatchSummaryImpl.Adapter.class)
 public interface BatchSummary {
 
-	/**
-	 * @return the duration as an {@link AuditDuration}
-	 */
 	AuditDuration getDuration();
 
-	/**
-	 * @return the number of jobs in the batch
-	 */
-	int getJobs();
+	ValidationBatchSummary getValidationSummary();
+	
+	FeaturesBatchSummary getFeaturesSummary();
+	
+	MetadataRepairBatchSummary getRepairSummary();
 
-	/**
-	 * @return the failed jobs, that is jobs where an exception was thrown and processing did not complete properly
-	 */
-	int getFailedJobs();
+	boolean isMultiJob();
 
-	/**
-	 * @return the number of valid PDF/A documents in the batch
-	 */
-	int getValidPdfaCount();
+	int getTotalJobs();
 
-	/**
-	 * @return the number of invalid PDF/A documents in the batch
-	 */
-	int getInvalidPdfaCount();
+	int getFailedParsingJobs();
 
-	/**
-	 * @return the number of validation jobs that threw an exception, if any
-	 */
-	int getValidationExceptionCount();
-
-	/**
-	 * @return the number of PDF documents for which features were extracted.
-	 */
-	int getFeatureCount();
+	int getFailedEncryptedJobs();
 }

--- a/core/src/main/java/org/verapdf/processor/reports/BatchSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/BatchSummaryImpl.java
@@ -1,60 +1,56 @@
 /**
  * This file is part of veraPDF Library core, a module of the veraPDF project.
- * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
- * All rights reserved.
- *
- * veraPDF Library core is free software: you can redistribute it and/or modify
- * it under the terms of either:
- *
- * The GNU General public license GPLv3+.
- * You should have received a copy of the GNU General Public License
- * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
- * tree.  If not, see http://www.gnu.org/licenses/ or
- * https://www.gnu.org/licenses/gpl-3.0.en.html.
- *
- * The Mozilla Public License MPLv2+.
- * You should have received a copy of the Mozilla Public License along with
- * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
- * If a copy of the MPL was not distributed with this file, you can obtain one at
- * http://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org> All rights
+ * reserved. veraPDF Library core is free software: you can redistribute it
+ * and/or modify it under the terms of either: The GNU General public license
+ * GPLv3+. You should have received a copy of the GNU General Public License
+ * along with veraPDF Library core as the LICENSE.GPL file in the root of the
+ * source tree. If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html. The Mozilla Public License
+ * MPLv2+. You should have received a copy of the Mozilla Public License along
+ * with veraPDF Library core as the LICENSE.MPL file in the root of the source
+ * tree. If a copy of the MPL was not distributed with this file, you can obtain
+ * one at http://mozilla.org/MPL/2.0/.
  */
 /**
  * 
  */
 package org.verapdf.processor.reports;
 
-import org.verapdf.component.AuditDuration;
-import org.verapdf.component.Components;
-
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import org.verapdf.component.AuditDuration;
+import org.verapdf.component.Components;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
  * @version 0.1 Created 2 Nov 2016:11:43:50
  */
-@XmlRootElement(name = "summary")
+@XmlRootElement(name = "batchSummary")
 final class BatchSummaryImpl implements BatchSummary {
+	private static final BatchSummary DEFAULT = new BatchSummaryImpl();
+	@XmlElement
+	private final ValidationBatchSummary validationReports;
+	@XmlElement
+	private final FeaturesBatchSummary featureReports;
+	@XmlElement
+	private final MetadataRepairBatchSummary repairReports;
 	@XmlElement
 	private final AuditDuration duration;
 	@XmlAttribute
-	private final int jobs;
+	private final int totalJobs;
 	@XmlAttribute
-	private final int failedJobs;
+	private final int failedToParse;
 	@XmlAttribute
-	private final int valid;
-	@XmlAttribute
-	private final int inValid;
-	@XmlAttribute
-	private final int validExcep;
-	@XmlAttribute
-	private final int features;
+	private final int encrypted;
 
 	private BatchSummaryImpl() {
-		this(Components.defaultDuration(), 0, 0, 0, 0, 0, 0);
+		this(Components.defaultDuration(), ValidationBatchSummaryImpl.defaultInstance(),
+				FeaturesBatchSummary.defaultInstance(), MetadataRepairBatchSummary.defaultInstance(), 0, 0, 0);
 	}
 
 	/**
@@ -62,16 +58,17 @@ final class BatchSummaryImpl implements BatchSummary {
 	 * @param jobs
 	 * @param failedJobs
 	 */
-	private BatchSummaryImpl(final AuditDuration duration, final int jobs, final int failedJobs, final int valid,
-			final int inValid, final int validExcep, final int features) {
+	private BatchSummaryImpl(final AuditDuration duration, final ValidationBatchSummary validationSummary,
+			final FeaturesBatchSummary featureSummary, final MetadataRepairBatchSummary repairSummary,
+			final int totalJobs, final int failedToParse, final int encrypted) {
 		super();
 		this.duration = duration;
-		this.jobs = jobs;
-		this.failedJobs = failedJobs;
-		this.valid = valid;
-		this.inValid = inValid;
-		this.validExcep = validExcep;
-		this.features = features;
+		this.validationReports = validationSummary;
+		this.featureReports = featureSummary;
+		this.repairReports = repairSummary;
+		this.totalJobs = totalJobs;
+		this.failedToParse = failedToParse;
+		this.encrypted = encrypted;
 	}
 
 	/**
@@ -82,20 +79,50 @@ final class BatchSummaryImpl implements BatchSummary {
 		return this.duration;
 	}
 
-	/**
-	 * @return the jobs
-	 */
 	@Override
-	public int getJobs() {
-		return this.jobs;
+	public ValidationBatchSummary getValidationSummary() {
+		return this.validationReports;
 	}
 
-	/**
-	 * @return the failedJobs
-	 */
 	@Override
-	public int getFailedJobs() {
-		return this.failedJobs;
+	public FeaturesBatchSummary getFeaturesSummary() {
+		return this.featureReports;
+	}
+
+	@Override
+	public MetadataRepairBatchSummary getRepairSummary() {
+		return this.repairReports;
+	}
+
+	@Override
+	public int getTotalJobs() {
+		return this.totalJobs;
+	}
+
+	@Override
+	public int getFailedParsingJobs() {
+		return this.failedToParse;
+	}
+
+	@Override
+	public boolean isMultiJob() {
+		return (this.totalJobs > 1);
+	}
+
+	@Override
+	public int getFailedEncryptedJobs() {
+		return this.encrypted;
+	}
+
+	public static final BatchSummary defaultInstance() {
+		return DEFAULT;
+	}
+
+	static final BatchSummary fromValues(final AuditDuration duration, final ValidationBatchSummary validationSummary,
+			final FeaturesBatchSummary featureSummary, final MetadataRepairBatchSummary repairSummary,
+			final int totalJobs, final int failedToParse, final int encrypted) {
+		return new BatchSummaryImpl(duration, validationSummary, featureSummary, repairSummary, totalJobs,
+				failedToParse, encrypted);
 	}
 
 	static class Adapter extends XmlAdapter<BatchSummaryImpl, BatchSummary> {
@@ -108,30 +135,5 @@ final class BatchSummaryImpl implements BatchSummary {
 		public BatchSummaryImpl marshal(BatchSummary summary) {
 			return (BatchSummaryImpl) summary;
 		}
-	}
-
-	static BatchSummary fromValues(final AuditDuration duration, final int jobs, final int failedJobs, final int valid,
-			final int inValid, final int validExcep, final int features) {
-		return new BatchSummaryImpl(duration, jobs, failedJobs, valid, inValid, validExcep, features);
-	}
-
-	@Override
-	public int getValidPdfaCount() {
-		return this.valid;
-	}
-
-	@Override
-	public int getInvalidPdfaCount() {
-		return this.inValid;
-	}
-
-	@Override
-	public int getValidationExceptionCount() {
-		return this.validExcep;
-	}
-
-	@Override
-	public int getFeatureCount() {
-		return this.features;
 	}
 }

--- a/core/src/main/java/org/verapdf/processor/reports/FeaturesBatchSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/FeaturesBatchSummary.java
@@ -1,0 +1,88 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 18 Apr 2017:21:43:38
+ */
+@XmlRootElement(name = "featureReports")
+public final class FeaturesBatchSummary extends AbstractBatchJobSummary {
+	private static final FeaturesBatchSummary DEFAULT = new FeaturesBatchSummary();
+
+	private FeaturesBatchSummary() {
+		this(0, 0);
+	}
+
+	/**
+	 * @param totalJobs
+	 * @param failedJobs
+	 */
+	private FeaturesBatchSummary(final int totalJobs, final int failedJobs) {
+		super(totalJobs, failedJobs);
+	}
+
+	@Override
+	public int getFailedJobCount() {
+		return this.failedJobs;
+	}
+
+	@Override
+	public int getTotalJobCount() {
+		return this.totalJobs;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + this.failedJobs;
+		result = prime * result + this.totalJobs;
+		return result;
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof AbstractBatchJobSummary)) {
+			return false;
+		}
+		AbstractBatchJobSummary other = (AbstractBatchJobSummary) obj;
+		if (this.failedJobs != other.failedJobs) {
+			return false;
+		}
+		if (this.totalJobs != other.totalJobs) {
+			return false;
+		}
+		return true;
+	}
+
+	public static FeaturesBatchSummary defaultInstance() {
+		return DEFAULT;
+	}
+
+	public static FeaturesBatchSummary fromValues(final int totalJobs, final int failedJobs) {
+		if (totalJobs < 0)
+			throw new IllegalArgumentException("Argument totalJobs must be >= 0"); //$NON-NLS-1$
+		if (failedJobs < 0)
+			throw new IllegalArgumentException("Argument failedJobs must be >= 0"); //$NON-NLS-1$
+		if (failedJobs > totalJobs)
+			throw new IllegalArgumentException("Argument failedJobs can not be > totalJobs"); //$NON-NLS-1$
+		return new FeaturesBatchSummary(totalJobs, failedJobs);
+	}
+}

--- a/core/src/main/java/org/verapdf/processor/reports/MetadataRepairBatchSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/MetadataRepairBatchSummary.java
@@ -1,0 +1,88 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 18 Apr 2017:21:43:38
+ */
+@XmlRootElement(name = "metadataRepairReports")
+public final class MetadataRepairBatchSummary extends AbstractBatchJobSummary {
+	private static final MetadataRepairBatchSummary DEFAULT = new MetadataRepairBatchSummary();
+
+	private MetadataRepairBatchSummary() {
+		this(0, 0);
+	}
+
+	/**
+	 * @param totalJobs
+	 * @param failedJobs
+	 */
+	private MetadataRepairBatchSummary(final int totalJobs, final int failedJobs) {
+		super(totalJobs, failedJobs);
+	}
+
+	@Override
+	public int getFailedJobCount() {
+		return this.failedJobs;
+	}
+
+	@Override
+	public int getTotalJobCount() {
+		return this.totalJobs;
+	}
+
+	public static MetadataRepairBatchSummary defaultInstance() {
+		return DEFAULT;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + this.failedJobs;
+		result = prime * result + this.totalJobs;
+		return result;
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof AbstractBatchJobSummary)) {
+			return false;
+		}
+		AbstractBatchJobSummary other = (AbstractBatchJobSummary) obj;
+		if (this.failedJobs != other.failedJobs) {
+			return false;
+		}
+		if (this.totalJobs != other.totalJobs) {
+			return false;
+		}
+		return true;
+	}
+
+	public static MetadataRepairBatchSummary fromValues(final int totalJobs, final int failedJobs) {
+		if (totalJobs < 0)
+			throw new IllegalArgumentException("Argument totalJobs must be >= 0"); //$NON-NLS-1$
+		if (failedJobs < 0)
+			throw new IllegalArgumentException("Argument failedJobs must be >= 0"); //$NON-NLS-1$
+		if (failedJobs > totalJobs)
+			throw new IllegalArgumentException("Argument failedJobs can not be > totalJobs"); //$NON-NLS-1$
+		return new MetadataRepairBatchSummary(totalJobs, failedJobs);
+	}
+}

--- a/core/src/main/java/org/verapdf/processor/reports/Reports.java
+++ b/core/src/main/java/org/verapdf/processor/reports/Reports.java
@@ -17,6 +17,7 @@
  */
 package org.verapdf.processor.reports;
 
+import org.verapdf.component.AuditDuration;
 import org.verapdf.component.Components;
 import org.verapdf.core.XmlSerialiser;
 import org.verapdf.pdfa.results.MetadataFixerResult;
@@ -55,9 +56,13 @@ public final class Reports {
 	 * @return a new {@link BatchSummary} instance created using the passed
 	 *         values
 	 */
-	public static final BatchSummary createBatchSummary(final Components.Timer timer, final int jobs,
-			final int failedJobs, final int valid, final int inValid, final int validExcep, final int features) {
-		return BatchSummaryImpl.fromValues(timer.stop(), jobs, failedJobs, valid, inValid, validExcep, features);
+	public static final BatchSummary createBatchSummary(final Components.Timer timer, final ValidationBatchSummary validationSummary,
+			final FeaturesBatchSummary featureSummary, final MetadataRepairBatchSummary repairSummary, final int totalJobs, final int failedToParse, final int encrypted) {
+		if (totalJobs < 0)  throw new IllegalArgumentException("Argument totalJobs must be >= 0"); //$NON-NLS-1$
+		if (failedToParse < 0)  throw new IllegalArgumentException("Argument failedToParse must be >= 0"); //$NON-NLS-1$
+		if (encrypted < 0)  throw new IllegalArgumentException("Argument encrypted must be >= 0"); //$NON-NLS-1$
+		if ((failedToParse + encrypted) > totalJobs) throw new IllegalArgumentException("Argument totalJobs must be >= arguments (failedJobs + encrypted)"); //$NON-NLS-1$
+		return BatchSummaryImpl.fromValues(timer.stop(), validationSummary, featureSummary, repairSummary, totalJobs, failedToParse, encrypted);
 	}
 
 	/**

--- a/core/src/main/java/org/verapdf/processor/reports/Summarisers.java
+++ b/core/src/main/java/org/verapdf/processor/reports/Summarisers.java
@@ -1,0 +1,112 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+import org.verapdf.processor.ProcessorResult;
+import org.verapdf.processor.TaskResult;
+import org.verapdf.processor.TaskType;
+
+/**
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 18 Apr 2017:22:21:39
+ */
+
+public final class Summarisers {
+	private Summarisers() {
+		assert (false);
+	}
+
+	public static ValidationBatchSummary defaultValidationSummary() {
+		return ValidationBatchSummaryImpl.DEFAULT;
+	}
+
+	public static ValidationBatchSummary validationSummaryFromValues(final int compliant, final int nonCompliant,
+			final int failedJobs) {
+		if (compliant < 0)
+			throw new IllegalArgumentException("Argument compliant must be >= 0"); //$NON-NLS-1$
+		if (nonCompliant < 0)
+			throw new IllegalArgumentException("Argument nonCompliant must be >= 0"); //$NON-NLS-1$
+		if (failedJobs < 0)
+			throw new IllegalArgumentException("Argument failedJobs must be >= 0"); //$NON-NLS-1$
+		return ValidationBatchSummaryImpl.fromValues(compliant, nonCompliant, failedJobs);
+	}
+
+	public static class ValidationSummaryBuilder extends AbstractSummaryBuilder {
+		private int compliant = 0;
+		private int nonCompliant = 0;
+
+		public ValidationSummaryBuilder() {
+			super(TaskType.VALIDATE);
+		}
+
+		public ValidationSummaryBuilder addResult(final ProcessorResult result) {
+			super.processResult(result);
+			TaskResult taskResult = result.getResultForTask(TaskType.VALIDATE);
+			if (taskResult != null && taskResult.isExecuted() && taskResult.isSuccess()) {
+				if (result.getValidationResult().isCompliant())
+					this.compliant++;
+				else
+					this.nonCompliant++;
+			}
+			return this;
+		}
+
+		public ValidationBatchSummary build() {
+			return ValidationBatchSummaryImpl.fromValues(this.compliant, this.nonCompliant, this.failed);
+		}
+	}
+
+	public static class FeatureSummaryBuilder extends AbstractSummaryBuilder {
+		public FeatureSummaryBuilder() {
+			super(TaskType.EXTRACT_FEATURES);
+		}
+
+		public FeatureSummaryBuilder addResult(final ProcessorResult result) {
+			super.processResult(result);
+			return this;
+		}
+
+		public FeaturesBatchSummary build() {
+			return FeaturesBatchSummary.fromValues(this.total, this.failed);
+		}
+	}
+
+	public static class RepairSummaryBuilder extends AbstractSummaryBuilder {
+		public RepairSummaryBuilder() {
+			super(TaskType.FIX_METADATA);
+		}
+
+		public RepairSummaryBuilder addResult(final ProcessorResult result) {
+			super.processResult(result);
+			return this;
+		}
+
+		public MetadataRepairBatchSummary build() {
+			return MetadataRepairBatchSummary.fromValues(this.total, this.failed);
+		}
+	}
+
+	private static abstract class AbstractSummaryBuilder {
+		protected int total = 0;
+		protected int failed = 0;
+		private final TaskType taskType;
+
+		protected AbstractSummaryBuilder(final TaskType taskType) {
+			this.taskType = taskType;
+		}
+
+		protected void processResult(final ProcessorResult result) {
+			this.total++;
+			if (!result.isPdf() || result.isEncryptedPdf()) {
+				this.failed++;
+			} else {
+				TaskResult taskResult = result.getResultForTask(this.taskType);
+				if (taskResult == null || !taskResult.isExecuted() || !taskResult.isSuccess()) {
+					this.failed++;
+				}
+			}
+		}
+	}
+}

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummary.java
@@ -1,0 +1,29 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * Holds the count of validation jobs and their statuses for a batch job
+ * summary.
+ * 
+ * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *         <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ * @version 0.1 Created 18 Apr 2017:16:53:46
+ */
+@XmlJavaTypeAdapter(ValidationBatchSummaryImpl.Adapter.class)
+public interface ValidationBatchSummary extends BatchJobSummary {
+	/**
+	 * @return the number of compliant PDF/As in the batch, that is the number
+	 *         of files that passed PDF/A validation.
+	 */
+	int getCompliantPdfaCount();
+
+	/**
+	 * @return the number of non-compliant PDF/As in the batch, that is the
+	 *         number of files that failed PDF/A validation.
+	 */
+	int getNonCompliantPdfaCount();
+}

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummaryImpl.java
@@ -1,0 +1,110 @@
+package org.verapdf.processor.reports;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+@XmlRootElement(name = "validationReports")
+final class ValidationBatchSummaryImpl extends AbstractBatchJobSummary implements ValidationBatchSummary {
+	static final ValidationBatchSummary DEFAULT = new ValidationBatchSummaryImpl();
+	@XmlAttribute
+	private final int compliant;
+	@XmlAttribute
+	private final int nonCompliant;
+
+	private ValidationBatchSummaryImpl() {
+		this(0, 0, 0);
+	}
+
+	private ValidationBatchSummaryImpl(final int compliant, final int nonCompliant, final int failedJobs) {
+		super(compliant + nonCompliant + failedJobs, failedJobs);
+		assert (compliant >= 0 && nonCompliant >= 0);
+		this.compliant = compliant;
+		this.nonCompliant = nonCompliant;
+	}
+
+	@Override
+	public int getCompliantPdfaCount() {
+		return this.compliant;
+	}
+
+	@Override
+	public int getNonCompliantPdfaCount() {
+		return this.nonCompliant;
+	}
+
+	@Override
+	public int getFailedJobCount() {
+		return this.failedJobs;
+	}
+
+	@Override
+	public int getTotalJobCount() {
+		return this.totalJobs;
+	}
+
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + this.totalJobs;
+		result = prime * result + this.failedJobs;
+		result = prime * result + this.compliant;
+		result = prime * result + this.nonCompliant;
+		return result;
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof ValidationBatchSummaryImpl)) {
+			return false;
+		}
+		ValidationBatchSummaryImpl other = (ValidationBatchSummaryImpl) obj;
+		if (this.totalJobs != other.totalJobs) {
+			return false;
+		}
+		if (this.failedJobs != other.failedJobs) {
+			return false;
+		}
+		if (this.compliant != other.compliant) {
+			return false;
+		}
+		if (this.nonCompliant != other.nonCompliant) {
+			return false;
+		}
+		return true;
+	}
+
+	static ValidationBatchSummary defaultInstance() {
+		return ValidationBatchSummaryImpl.DEFAULT;
+	}
+
+	static ValidationBatchSummary fromValues(final int compliant, final int nonCompliant, final int failedJobs) {
+		return new ValidationBatchSummaryImpl(compliant, nonCompliant, failedJobs);
+	}
+
+	static class Adapter extends XmlAdapter<ValidationBatchSummaryImpl, ValidationBatchSummary> {
+		@Override
+		public ValidationBatchSummary unmarshal(ValidationBatchSummaryImpl summary) {
+			return summary;
+		}
+
+		@Override
+		public ValidationBatchSummaryImpl marshal(ValidationBatchSummary summary) {
+			return (ValidationBatchSummaryImpl) summary;
+		}
+	}
+}

--- a/core/src/main/java/org/verapdf/report/HTMLReport.java
+++ b/core/src/main/java/org/verapdf/report/HTMLReport.java
@@ -60,7 +60,7 @@ public final class HTMLReport {
 	 */
 	public static void writeHTMLReport(InputStream source, OutputStream destination, BatchSummary summary, String wikiPath,
 			boolean isFullHTML) throws TransformerException {
-		String reportPath = (summary.getJobs() > 1) ? summaryReport : detailedReport;
+		String reportPath = (summary.isMultiJob()) ? summaryReport : detailedReport;
 		Map<String, String> arguments = new HashMap<>();
 		arguments.put("wikiPath", wikiPath); //$NON-NLS-1$
 		arguments.put("isFullHTML", Boolean.toString(isFullHTML)); //$NON-NLS-1$

--- a/core/src/main/resources/org/verapdf/policy/MergeMrrPolicy.xsl
+++ b/core/src/main/resources/org/verapdf/policy/MergeMrrPolicy.xsl
@@ -79,7 +79,7 @@
     <xsl:copy>
       <xsl:copy-of select="buildInformation"/>
       <xsl:apply-templates select="jobs"/>
-      <xsl:copy-of select="summary"/>
+      <xsl:copy-of select="batchSummary"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/core/src/main/resources/org/verapdf/report/DetailedHtmlReport.xsl
+++ b/core/src/main/resources/org/verapdf/report/DetailedHtmlReport.xsl
@@ -120,7 +120,7 @@
                 <xsl:if test="/report/jobs/job/validationReport/@isCompliant">
                     <tr>
                         <td width="200" class="{$validClass}">
-                            Compliance status:
+                            PDF/A compliance:
                         </td>
                         <td class="{$validClass}">
                             <xsl:if test="/report/jobs/job/validationReport/@isCompliant = 'true'">
@@ -148,11 +148,11 @@
                         <xsl:choose>
                             <xsl:when
                                     test="/report/jobs/job/policyReport/@failedChecks > 0">
-                                <td class="invalid">Policy status:</td>
+                                <td class="invalid">Policy compliance:</td>
                                 <td class="invalid">Failed</td>
                             </xsl:when>
                             <xsl:otherwise>
-                                <td class="valid">Policy status:</td>
+                                <td class="valid">Policy compliance:</td>
                                 <td class="valid">Passed</td>
                             </xsl:otherwise>
                         </xsl:choose>
@@ -168,7 +168,7 @@
                     </td>
                     <td>
                         <xsl:value-of
-                                select="/report/buildInformation/releaseDetails[1]/@version"/>
+                                select="/report/buildInformation/releaseDetails[@id='gui']/@version"/>
                     </td>
                 </tr>
                 <tr>
@@ -177,7 +177,7 @@
                     </td>
                     <td>
                         <xsl:value-of
-                                select="/report/buildInformation/releaseDetails[1]/@buildDate"/>
+                                select="/report/buildInformation/releaseDetails[@id='gui']/@buildDate"/>
                     </td>
                 </tr>
                 <tr>
@@ -185,7 +185,7 @@
                         <b>Processing time:</b>
                     </td>
                     <td>
-                        <xsl:value-of select="/report/jobs/job/processingTime"/>
+                        <xsl:value-of select="/report/jobs/job/duration"/>
                     </td>
                 </tr>
                 <xsl:if test="/report/jobs/job/validationReport/details/@passedRules or /report/jobs/job/validationReport/details/@failedRules">

--- a/core/src/main/resources/org/verapdf/report/SummaryHtmlReport.xsl
+++ b/core/src/main/resources/org/verapdf/report/SummaryHtmlReport.xsl
@@ -9,7 +9,7 @@
     <xsl:output method="html" indent="yes" />
     <!-- Parameter to select a full HTML document (true) or a fragment within div (false) -->
     <xsl:param name="isFullHTML" select="'true'" />
-    <!-- Prameter to set the base path to the Wiki instance -->
+    <!-- Parameter to set the base path to the Wiki instance -->
     <xsl:param name="wikiPath" select="'https://github.com/veraPDF/veraPDF-validation-profiles/wiki/'"/>
     <xsl:strip-space elements="*"/>
 
@@ -101,7 +101,7 @@
           <!-- Display the build information -->
           <xsl:apply-templates select="/report/buildInformation"/>
           <!-- Display the summary information -->
-          <xsl:apply-templates select="/report/summary"/>
+          <xsl:apply-templates select="/report/batchSummary"/>
           <!-- Call the job iteration template -->
           <xsl:apply-templates select="/report/jobs"/>
     </xsl:template>
@@ -115,7 +115,7 @@
                   <b>Version:</b>
               </td>
               <td class="lefted">
-                  <xsl:value-of select="releaseDetails[1]/@version"/>
+                  <xsl:value-of select="releaseDetails[@id='gui']/@version"/>
               </td>
           </tr>
           <tr>
@@ -123,44 +123,47 @@
                   <b>Build Date:</b>
               </td>
               <td class="lefted">
-                  <xsl:value-of select="releaseDetails[1]/@buildDate"/>
+                  <xsl:value-of select="releaseDetails[@id='gui']/@buildDate"/>
               </td>
           </tr>
         </table>
     </xsl:template>
 
     <!-- Display the summary information -->
-    <xsl:template match="/report/summary">
+    <xsl:template match="/report/batchSummary">
       <xsl:variable name="isPolicy" select="/report/jobs/job/policyReport" />
       <h2>Batch Summary</h2>
       <table border="0" id="table2">
           <tr>
             <th>Processing time</th>
             <th>Total Jobs</th>
-            <th>Exceptions</th>
-            <th>Valid</th>
-            <th>Invalid</th>
+            <th>Failed to Parse</th>
+            <th>Encrypted</th>
+            <th>PDF/A Compliant</th>
+            <th>Not PDF/A Compliant</th>
             <xsl:if test="$isPolicy">
-              <th>Passed Policy</th>
-              <th>Failed Policy</th>
+              <th>Policy Compliant</th>
+              <th>Not Policy Compliant</th>
             </xsl:if>
           </tr>
           <tr>
               <td>
-                  <xsl:value-of select="duration"/>
+                  <xsl:value-of select="duration/text()"/>
               </td>
               <td>
-                  <xsl:value-of
-                          select="@jobs"/>
+                  <xsl:value-of select="@totalJobs"/>
               </td>
               <td>
-                  <xsl:value-of select="@failedJobs"/>
+                  <xsl:value-of select="@failedToParse"/>
               </td>
               <td>
-                  <xsl:value-of select="@valid"/>
+                  <xsl:value-of select="@encrypted"/>
               </td>
               <td>
-                  <xsl:value-of select="@inValid"/>
+                  <xsl:value-of select="validationReports/@compliant"/>
+              </td>
+              <td>
+                  <xsl:value-of select="validationReports/@nonCompliant"/>
               </td>
               <xsl:if test="$isPolicy">
                 <td>
@@ -182,14 +185,13 @@
         <tr>
           <th>File Name</th>
           <th>Validation Profile</th>
-          <th>Is Valid</th>
+          <th>PDF/A Compliance</th>
           <th>Passed Rules</th>
           <th>Failed Rules</th>
           <th>Passed Checks</th>
           <th>Failed Checks</th>
           <xsl:if test="$isPolicy">
-            <th>Passed Policy</th>
-            <th>Failed Policy</th>
+            <th>Failed Policy Checks</th>
           </xsl:if>
           <th>Duration</th>
         </tr>
@@ -238,7 +240,7 @@
             </td>
             <xsl:apply-templates select="policyReport" />
             <td>
-              <xsl:value-of select="processingTime" />
+              <xsl:value-of select="duration/text()" />
             </td>
           </tr>
         </xsl:for-each>
@@ -246,11 +248,28 @@
     </xsl:template>
 
     <xsl:template match="/report/jobs/job/policyReport">
-      <td>
-        <xsl:value-of select="@passedChecks" />
-      </td>
-      <td>
-        <xsl:value-of select="@failedChecks" />
+      <xsl:variable name="policyClass">
+        <xsl:choose>
+          <xsl:when test="@failedChecks > 0">
+            <xsl:value-of select="'invalid'" />
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="'valid'" />
+            </xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
+      <xsl:variable name="policyResult">
+        <xsl:choose>
+          <xsl:when test="@failedChecks > 0">
+            <xsl:value-of select="'Failed'" />
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="'Passed'" />
+            </xsl:otherwise>
+          </xsl:choose>
+      </xsl:variable>
+      <td class="{$policyClass}">
+          <xsl:value-of select="$policyResult"/>
       </td>
     </xsl:template>
 

--- a/core/src/test/java/org/verapdf/processor/reports/ValidationBatchSummaryTest.java
+++ b/core/src/test/java/org/verapdf/processor/reports/ValidationBatchSummaryTest.java
@@ -1,0 +1,123 @@
+/**
+ * 
+ */
+package org.verapdf.processor.reports;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.xml.bind.JAXBException;
+
+import org.junit.Test;
+import org.verapdf.core.XmlSerialiser;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * @author  <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *          <a href="https://github.com/carlwilson">carlwilson AT github</a>
+ *
+ * @version 0.1
+ * 
+ * Created 18 Apr 2017:17:14:00
+ */
+@SuppressWarnings("static-method")
+public class ValidationBatchSummaryTest {
+
+    @Test
+    public final void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(ValidationBatchSummaryImpl.class).verify();
+        EqualsVerifier.forClass(FeaturesBatchSummary.class).verify();
+        EqualsVerifier.forClass(MetadataRepairBatchSummary.class).verify();
+    }
+
+    /**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#getCompliantPdfaTota1()}.
+	 */
+	@Test
+	public void testGetCompliantPdfaTota1() {
+		ValidationBatchSummary summary = ValidationBatchSummaryImpl.fromValues(12, 0, 0);
+		assertTrue(summary.getCompliantPdfaCount() == 12);
+		summary = ValidationBatchSummaryImpl.fromValues(10, 12, 0);
+		assertTrue(summary.getCompliantPdfaCount() == 10);
+		summary = ValidationBatchSummaryImpl.fromValues(15, 0, 20);
+		assertTrue(summary.getCompliantPdfaCount() == 15);
+		summary = ValidationBatchSummaryImpl.fromValues(25, 13, 20);
+		assertTrue(summary.getCompliantPdfaCount() == 25);
+		summary = ValidationBatchSummaryImpl.fromValues(0, 13, 20);
+		assertTrue(summary.getCompliantPdfaCount() == 0);
+	}
+
+	/**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#getNonCompliantPdfaTota1()}.
+	 */
+	@Test
+	public void testGetNonCompliantPdfaTota1() {
+		ValidationBatchSummary summary = ValidationBatchSummaryImpl.fromValues(0, 12, 0);
+		assertTrue(summary.getNonCompliantPdfaCount() == 12);
+		summary = ValidationBatchSummaryImpl.fromValues(10, 15, 0);
+		assertTrue(summary.getNonCompliantPdfaCount() == 15);
+		summary = ValidationBatchSummaryImpl.fromValues(0, 18, 20);
+		assertTrue(summary.getNonCompliantPdfaCount() == 18);
+		summary = ValidationBatchSummaryImpl.fromValues(25, 13, 20);
+		assertTrue(summary.getNonCompliantPdfaCount() == 13);
+		summary = ValidationBatchSummaryImpl.fromValues(13, 0, 20);
+		assertTrue(summary.getNonCompliantPdfaCount() == 0);
+	}
+
+	/**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#getFailedJobCount()}.
+	 */
+	@Test
+	public void testGetFailedJobCount() {
+		ValidationBatchSummary summary = ValidationBatchSummaryImpl.fromValues(0, 0, 12);
+		assertTrue(summary.getFailedJobCount() == 12);
+		summary = ValidationBatchSummaryImpl.fromValues(10, 0, 15);
+		assertTrue(summary.getFailedJobCount() == 15);
+		summary = ValidationBatchSummaryImpl.fromValues(0, 20, 18);
+		assertTrue(summary.getFailedJobCount() == 18);
+		summary = ValidationBatchSummaryImpl.fromValues(25, 13, 20);
+		assertTrue(summary.getFailedJobCount() == 20);
+		summary = ValidationBatchSummaryImpl.fromValues(13, 0, 4);
+		assertTrue(summary.getFailedJobCount() == 4);
+	}
+
+	/**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#getTotalJobCount()}.
+	 */
+	@Test
+	public void testGetTotalJobCount() throws JAXBException {
+		ValidationBatchSummary summary = ValidationBatchSummaryImpl.fromValues(0, 0, 12);
+		assertTrue(summary.getTotalJobCount() == 12);
+		summary = ValidationBatchSummaryImpl.fromValues(10, 0, 15);
+		assertTrue(summary.getTotalJobCount() == 25);
+		summary = ValidationBatchSummaryImpl.fromValues(0, 20, 18);
+		assertTrue(summary.getTotalJobCount() == 38);
+		summary = ValidationBatchSummaryImpl.fromValues(25, 13, 20);
+		assertTrue(summary.getTotalJobCount() == 58);
+		summary = ValidationBatchSummaryImpl.fromValues(13, 0, 4);
+		assertTrue(summary.getTotalJobCount() == 17);
+		System.out.println(XmlSerialiser.toXml(summary, true, true));
+	}
+
+	/**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#defaultInstance()}.
+	 */
+	@Test
+	public void testDefaultInstance() {
+		ValidationBatchSummary defaultInstance = ValidationBatchSummaryImpl.defaultInstance();
+		assertTrue(defaultInstance == ValidationBatchSummaryImpl.defaultInstance());
+	}
+
+	/**
+	 * Test method for {@link org.verapdf.processor.reports.ValidationBatchSummaryImpl#fromValues(int, int, int)}.
+	 */
+	@Test
+	public void testFromValues() {
+		ValidationBatchSummary instance = ValidationBatchSummaryImpl.fromValues(0, 0, 0);
+		assertFalse(instance == ValidationBatchSummaryImpl.defaultInstance());
+		assertEquals(ValidationBatchSummaryImpl.defaultInstance(), instance);
+	}
+
+}


### PR DESCRIPTION
Closes #707, closes veraPDF/veraPDF-validation#159
- added summary types for validation, features and metadata repair;
- created convenience builders for summary types;
- parsing failures and encrypted PDFs now have dedicated fields;
- tests for ValidationBatchSummary;
- fixed changed paths in XSLT report templates;
- ensured that HTML report picks up gui app version details; and
- done away with reporting of policy check numbers.