### PR TITLE
Change millisecond separator to a standard decimal mark

### DIFF
--- a/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
+++ b/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
@@ -122,7 +122,7 @@ public final class AuditDurationImpl implements AuditDuration {
 		long millis = difference % msInSec;
 
 		try (Formatter formatter = new Formatter()) {
-			formatter.format("%02d:%02d:%02d:%03d", Long.valueOf(hours), Long.valueOf(minutes), Long.valueOf(seconds), //$NON-NLS-1$
+			formatter.format("%02d:%02d:%02d.%03d", Long.valueOf(hours), Long.valueOf(minutes), Long.valueOf(seconds), //$NON-NLS-1$
 					Long.valueOf(millis));
 			return formatter.toString();
 		}

--- a/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
+++ b/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
@@ -45,8 +45,8 @@ public class AuditDurationImplTest {
 		long second = 1000;
 		long minute = 60 * second;
 		long hour = 60 * minute;
-		assertEquals("00:00:00:000", AuditDurationImpl.getStringDuration(0));
-		assertEquals("01:23:45:678", AuditDurationImpl.getStringDuration(hour + 23 * minute + 45 * second + 678));
+		assertEquals("00:00:00.000", AuditDurationImpl.getStringDuration(0));
+		assertEquals("01:23:45.678", AuditDurationImpl.getStringDuration(hour + 23 * minute + 45 * second + 678));
 	}
 
 	@Test


### PR DESCRIPTION
More closely aligns with English convention (".") and ISO date-time standard 8601 ("," or ".").