### PR TITLE
REL - Release v1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ veraPDF-library
 [![CodeCov Coverage](https://img.shields.io/codecov/c/github/veraPDF/veraPDF-library.svg)](https://codecov.io/gh/veraPDF/veraPDF-library/ "CodeCov coverage")
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/cfafc08b44eb49b6aa790d6aaff09cd3)](https://www.codacy.com/app/carlwilson/veraPDF-library?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=veraPDF/veraPDF-library&amp;utm_campaign=Badge_Grade "Codacy grade")
 
+[![GitHub issues](https://img.shields.io/github/issues/veraPDF/veraPDF-library.svg)](https://github.com/veraPDF/veraPDF-library/issues "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-closed/veraPDF/veraPDF-library.svg)](https://github.com/veraPDF/veraPDF-library/issues-closed "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-pr/veraPDF/veraPDF-library.svg)](https://github.com/veraPDF/veraPDF-library/issues-pr "Open issues on GitHub")
+[![GitHub issues](https://img.shields.io/github/issues-pr-closed/veraPDF/veraPDF-library.svg)](https://github.com/veraPDF/veraPDF-library/issues-pr-closed "Open issues on GitHub")
+
 Licensing
 ---------
 The veraPDF PDF/A Validation Library is dual-licensed, see:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,27 @@
+Version 1.10 (November 30, 2017)
+==========================
+
+## PDF Parser:
+- fixed retrieval of glyph widths from PS and CFF font programs (multiple issues);
+- optimized creation and cleanup of temporary files; and
+- optimized parsing of text-related data in PDF documents (up to 3 times faster for PDF documents with primarily text content).
+
+## Conformance Checker:
+- fixed checks on the presence of SMask, NeedApperane keys in case of invalid value types;
+- fixed ByteRange check of digital signatures in case of incrementally updated files;
+- fixed Unicode checks in PDF/A-1A validation for Type1 and Type3 fonts;
+- fixed inheritance of /FT entry in Widget annotations; and
+- fixed role map retrieval in case of remapping standard structure types.
+
+## Policy Checker:
+- fixed Schematron warnings in Policy checks; and
+- fixed issue with access to temp reports from Schematron stylesheets on some systems and in case of Java 9.
+
+## Application enhancements:
+- fixed various issues caused by Java 9, particularly a problem in the start up scripts; and
+- fixed access to PDF resources in case of veraPDF integration into web applications.
+
+
 Version 1.8 (August 9, 2017)
 ==========================
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>verapdf-library</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.9.0-SNAPSHOT</version>
+    <version>1.10.0</version>
   </parent>
 
   <artifactId>core</artifactId>

--- a/core/src/main/java/org/verapdf/metadata/fixer/utils/MetadataFixerConstants.java
+++ b/core/src/main/java/org/verapdf/metadata/fixer/utils/MetadataFixerConstants.java
@@ -42,7 +42,7 @@ public class MetadataFixerConstants {
 	public static final String INFO_CREATION_DATE = "CreationDate";
 	public static final String INFO_MODIFICATION_DATE = "ModDate";
 
-	public static final String PROCESSED_OBJECTS_PROPERTIES_PATH = "/org/verapdf/metadata/fixer/processed-objects.properties";
+	public static final String PROCESSED_OBJECTS_PROPERTIES_PATH = "org/verapdf/metadata/fixer/processed-objects.properties";
 	public static final String RULE_DESCRIPTION_TAG = "ruleDescription";
 	public static final String OBJECT_TYPE_TAG = "objectType";
 	public static final String TEST_TAG = "test";

--- a/core/src/main/java/org/verapdf/metadata/fixer/utils/parser/XMLProcessedObjectsParser.java
+++ b/core/src/main/java/org/verapdf/metadata/fixer/utils/parser/XMLProcessedObjectsParser.java
@@ -20,21 +20,6 @@
  */
 package org.verapdf.metadata.fixer.utils.parser;
 
-import static org.verapdf.metadata.fixer.utils.MetadataFixerConstants.OBJECT_TYPE_TAG;
-import static org.verapdf.metadata.fixer.utils.MetadataFixerConstants.PROCESSED_OBJECTS_PROPERTIES_PATH;
-import static org.verapdf.metadata.fixer.utils.MetadataFixerConstants.RULE_DESCRIPTION_TAG;
-import static org.verapdf.metadata.fixer.utils.MetadataFixerConstants.TEST_TAG;
-
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.verapdf.metadata.fixer.utils.model.ProcessedObjects;
 import org.verapdf.metadata.fixer.utils.model.RuleDescription;
 import org.verapdf.pdfa.flavours.PDFAFlavour;
@@ -42,6 +27,17 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.verapdf.metadata.fixer.utils.MetadataFixerConstants.*;
 
 /**
  * @author Evgeniy Muravitskiy
@@ -51,6 +47,7 @@ public class XMLProcessedObjectsParser implements ProcessedObjectsParser {
     private static final String XML_PROCESSED_OBJECTS_PATH_PROPERTY_PDFA_1 = "processed.objects.path.pdfa_1";
     private static final String XML_PROCESSED_OBJECTS_PATH_PROPERTY_PDFA_2_3 = "processed.objects.path.pdfa_2_3";
 
+    private static ClassLoader cl = XMLProcessedObjectsParser.class.getClassLoader();
     private static ProcessedObjectsParser instance;
 
     private XMLProcessedObjectsParser() {
@@ -61,14 +58,12 @@ public class XMLProcessedObjectsParser implements ProcessedObjectsParser {
     public ProcessedObjects getProcessedObjects(PDFAFlavour flavour)
             throws IOException, ParserConfigurationException, SAXException {
         Properties prop = new Properties();
-        try (InputStream inputStream = ClassLoader.class
-                .getResourceAsStream(PROCESSED_OBJECTS_PROPERTIES_PATH)) {
+        try (InputStream inputStream = cl.getResourceAsStream(PROCESSED_OBJECTS_PROPERTIES_PATH)) {
             prop.load(inputStream);
         }
         String appliedObjectsPath = prop.getProperty(this
                 .getProcessedObjectsPathProperty(flavour));
-        try (InputStream xml = ClassLoader.class
-                .getResourceAsStream(appliedObjectsPath)) {
+        try (InputStream xml = cl.getResourceAsStream(appliedObjectsPath)) {
             return this.getProcessedObjects(xml);
         }
     }

--- a/core/src/main/resources/org/verapdf/metadata/fixer/processed-objects.properties
+++ b/core/src/main/resources/org/verapdf/metadata/fixer/processed-objects.properties
@@ -1,2 +1,2 @@
-processed.objects.path.pdfa_1 = /org/verapdf/metadata/fixer/processedObjectsPDFA_1.xml
-processed.objects.path.pdfa_2_3 = /org/verapdf/metadata/fixer/processedObjectsPDFA_2_3.xml
+processed.objects.path.pdfa_1 = org/verapdf/metadata/fixer/processedObjectsPDFA_1.xml
+processed.objects.path.pdfa_2_3 = org/verapdf/metadata/fixer/processedObjectsPDFA_2_3.xml

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
   <groupId>org.verapdf</groupId>
   <artifactId>verapdf-library</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>1.10.0</version>
   <packaging>pom</packaging>
 
   <name>veraPDF PDF/A Validation Library</name>
@@ -51,7 +51,7 @@
   </scm>
 
   <properties>
-    <verapdf.model.version>[1.9.0,1.10.0)</verapdf.model.version>
+    <verapdf.model.version>[1.10.0,1.11.0)</verapdf.model.version>
     <verapdf.xmp.version>[0.12.0,0.13.0)</verapdf.xmp.version>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>


### PR DESCRIPTION
- fixed metadata fixed for Java 9;
- bumped minor -> 1.10 for release;
- updated model dependency; and
- added issue and PR badges to README.md.