### PR TITLE
 REL - Development version v1.11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>verapdf-library</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.10.0</version>
+    <version>1.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>core</artifactId>
@@ -45,8 +45,8 @@
       <artifactId>verapdf-xmp-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>rhino</groupId>
-      <artifactId>js</artifactId>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>org.verapdf</groupId>
   <artifactId>verapdf-parent</artifactId>
-  <version>1.12.1</version>
+  <version>1.12.2</version>
   <packaging>pom</packaging>
 
   <name>veraPDF Consortium parent </name>
@@ -323,6 +323,15 @@
       </plugins>
     </pluginManagement>
   </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.sonar-plugins.java</groupId>
+      <artifactId>sonar-jacoco-listeners</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@
   <parent>
     <artifactId>verapdf-parent</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.4.1</version>
+    <version>1.12.1</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
   <groupId>org.verapdf</groupId>
   <artifactId>verapdf-library</artifactId>
-  <version>1.10.0</version>
+  <version>1.11.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>veraPDF PDF/A Validation Library</name>
@@ -51,7 +51,7 @@
   </scm>
 
   <properties>
-    <verapdf.model.version>[1.10.0,1.11.0)</verapdf.model.version>
+    <verapdf.model.version>[1.11.0,1.12.0)</verapdf.model.version>
     <verapdf.xmp.version>[0.12.0,0.13.0)</verapdf.xmp.version>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>
@@ -95,15 +95,15 @@
       <dependency>
         <groupId>nl.jqno.equalsverifier</groupId>
         <artifactId>equalsverifier</artifactId>
-        <version>1.5.1</version>
+        <version>1.7.8</version>
         <scope>test</scope>
       </dependency>
 
       <!-- Mozilla Rhino JavaScript engine -->
       <dependency>
-        <groupId>rhino</groupId>
-        <artifactId>js</artifactId>
-        <version>1.7R2</version>
+        <groupId>org.mozilla</groupId>
+        <artifactId>rhino</artifactId>
+        <version>1.7.7.2</version>
       </dependency>
 
       <dependency>
@@ -121,7 +121,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
         <scope>test</scope>
       </dependency>
 
@@ -133,7 +133,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.4</version>
         <configuration>
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <artifactId>verapdf-parent</artifactId>
     <groupId>org.verapdf</groupId>
-    <version>1.12.1</version>
+    <version>1.12.2</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
- bumped minor version -> 1.11 for development;
- updated model dependency to 1.11;
- updated parent pom version to 1.12.2 for Java 8;
- updated Mozilla Rhino dependency to 1.7.7.2; and
- updated Maven plugins and dependencies.