### PR TITLE
FIX - Java 11 javax.xml.bind dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,31 +40,52 @@
       <groupId>org.verapdf</groupId>
       <artifactId>pdf-model</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.verapdf</groupId>
       <artifactId>verapdf-xmp-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+
     <dependency>
       <groupId>org.mozilla</groupId>
       <artifactId>rhino</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
       <version>2.2.1</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
         <groupId>net.java.dev.stax-utils</groupId>
         <artifactId>stax-utils</artifactId>
@@ -76,7 +97,9 @@
             </exclusion>
         </exclusions>
     </dependency>
+
   </dependencies>
+
   <build>
     <resources>
       <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,24 @@
         <scope>test</scope>
       </dependency>
 
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0.1</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
- added missing dependencies to main `pom.xml` dependency management section; and
- added required dependencies to `core/pom.xml`.