### PR TITLE
Fixed issue: #905

### DIFF
--- a/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
@@ -58,24 +58,45 @@ abstract class AbstractFoundry implements VeraPDFFoundry {
 	}
 
 	@Override
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails) {
-		return ValidatorFactory.createValidator(flavour, logSuccess, viewFails);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess) {
+		return ValidatorFactory.createValidator(flavour, logSuccess);
 	}
 
 	@Override
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails) {
-		return ValidatorFactory.createValidator(profile, logSuccess, viewFails);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int maxCheckedDetailsPerRule) {
+		return ValidatorFactory.createValidator(flavour, logSuccess, maxCheckedDetailsPerRule);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures) {
-		return ValidatorFactory.createValidator(flavour, viewFails, maxFailures);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess) {
+		return ValidatorFactory.createValidator(profile, logSuccess);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures) {
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int maxCheckedDetailsPerRule) {
+		return ValidatorFactory.createValidator(profile, logSuccess, maxCheckedDetailsPerRule);
+	}
+
+	@Override
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures) {
+		return ValidatorFactory.createValidator(flavour, maxFailures);
+	}
+
+	@Override
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxCheckedDetailsPerRule, int maxFailures) {
+		return ValidatorFactory.createValidator(flavour, maxCheckedDetailsPerRule, maxFailures);
+	}
+
+	@Override
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures) {
 		return ValidatorFactory.createValidator(profile, maxFailures);
 	}
+
+	@Override
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxCheckedDetailsPerRule, int maxFailures) {
+		return ValidatorFactory.createValidator(profile, maxCheckedDetailsPerRule, maxFailures);
+	}
+
 
 	@Override
 	public PDFAFlavour defaultFlavour() {

--- a/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
@@ -39,41 +39,41 @@ abstract class AbstractFoundry implements VeraPDFFoundry {
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(config.getFlavour(), config.getViewFails(), config.getMaxFails());
-		return createValidator(config.getFlavour(), config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(config.getFlavour(), config.getMaxFails());
+		return createValidator(config.getFlavour(), config.isRecordPasses());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, PDFAFlavour flavour) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(flavour, config.getViewFails(), config.getMaxFails());
-		return createValidator(flavour, config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(flavour, config.getMaxFails());
+		return createValidator(flavour, config.isRecordPasses());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, ValidationProfile profile) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(profile, config.getViewFails(), config.getMaxFails());
-		return createValidator(profile, config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(profile, config.getMaxFails());
+		return createValidator(profile, config.isRecordPasses());
 	}
 
 	@Override
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails) {
-		return ValidatorFactory.createValidator(flavour, logSuccess, viewFails);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess) {
+		return ValidatorFactory.createValidator(flavour, logSuccess);
 	}
 
 	@Override
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails) {
-		return ValidatorFactory.createValidator(profile, logSuccess, viewFails);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess) {
+		return ValidatorFactory.createValidator(profile, logSuccess);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures) {
-		return ValidatorFactory.createValidator(flavour, viewFails, maxFailures);
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures) {
+		return ValidatorFactory.createValidator(flavour, maxFailures);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures) {
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures) {
 		return ValidatorFactory.createValidator(profile, maxFailures);
 	}
 

--- a/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
@@ -39,41 +39,41 @@ abstract class AbstractFoundry implements VeraPDFFoundry {
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(config.getFlavour(), config.getMaxFails());
-		return createValidator(config.getFlavour(), config.isRecordPasses());
+			return createFailFastValidator(config.getFlavour(), config.getViewFails(), config.getMaxFails());
+		return createValidator(config.getFlavour(), config.isRecordPasses(), config.getViewFails());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, PDFAFlavour flavour) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(flavour, config.getMaxFails());
-		return createValidator(flavour, config.isRecordPasses());
+			return createFailFastValidator(flavour, config.getViewFails(), config.getMaxFails());
+		return createValidator(flavour, config.isRecordPasses(), config.getViewFails());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, ValidationProfile profile) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(profile, config.getMaxFails());
-		return createValidator(profile, config.isRecordPasses());
+			return createFailFastValidator(profile, config.getViewFails(), config.getMaxFails());
+		return createValidator(profile, config.isRecordPasses(), config.getViewFails());
 	}
 
 	@Override
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess) {
-		return ValidatorFactory.createValidator(flavour, logSuccess);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails) {
+		return ValidatorFactory.createValidator(flavour, logSuccess, viewFails);
 	}
 
 	@Override
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess) {
-		return ValidatorFactory.createValidator(profile, logSuccess);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails) {
+		return ValidatorFactory.createValidator(profile, logSuccess, viewFails);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures) {
-		return ValidatorFactory.createValidator(flavour, maxFailures);
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures) {
+		return ValidatorFactory.createValidator(flavour, viewFails, maxFailures);
 	}
 
 	@Override
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures) {
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures) {
 		return ValidatorFactory.createValidator(profile, maxFailures);
 	}
 

--- a/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/AbstractFoundry.java
@@ -39,22 +39,22 @@ abstract class AbstractFoundry implements VeraPDFFoundry {
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(config.getFlavour(), config.getViewFails(), config.getMaxFails());
-		return createValidator(config.getFlavour(), config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(config.getFlavour(), config.getMaxCheckedDetailsPerRule(), config.getMaxFails());
+		return createValidator(config.getFlavour(), config.isRecordPasses(), config.getMaxCheckedDetailsPerRule());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, PDFAFlavour flavour) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(flavour, config.getViewFails(), config.getMaxFails());
-		return createValidator(flavour, config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(flavour, config.getMaxCheckedDetailsPerRule(), config.getMaxFails());
+		return createValidator(flavour, config.isRecordPasses(), config.getMaxCheckedDetailsPerRule());
 	}
 
 	@Override
 	public PDFAValidator createValidator(ValidatorConfig config, ValidationProfile profile) {
 		if (config.getMaxFails() > 0)
-			return createFailFastValidator(profile, config.getViewFails(), config.getMaxFails());
-		return createValidator(profile, config.isRecordPasses(), config.getViewFails());
+			return createFailFastValidator(profile, config.getMaxCheckedDetailsPerRule(), config.getMaxFails());
+		return createValidator(profile, config.isRecordPasses(), config.getMaxCheckedDetailsPerRule());
 	}
 
 	@Override

--- a/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
@@ -168,7 +168,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
@@ -184,7 +184,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -203,7 +203,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures);
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -221,7 +221,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures);
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures);
 
 	/**
 	 * Obtain a new {@link MetadataFixer} instance.

--- a/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
@@ -168,7 +168,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
@@ -184,7 +184,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -203,7 +203,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures);
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -221,7 +221,7 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures);
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures);
 
 	/**
 	 * Obtain a new {@link MetadataFixer} instance.

--- a/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
+++ b/core/src/main/java/org/verapdf/pdfa/VeraPDFFoundry.java
@@ -111,16 +111,16 @@ public interface VeraPDFFoundry extends Component {
 	 *             if the PDF to be parsed is encrypted
 	 */
 	public PDFAParser createParser(File pdfFile)
-		throws ModelParsingException, EncryptedPdfException;
+			throws ModelParsingException, EncryptedPdfException;
 
-		/**
-		 * Obtain a new {@link PDFAValidator} instance.
-		 *
-		 * @param config
-		 *            a {@link ValidatorConfig} instance used to configure the
-		 *            {@link PDFAValidator}
-		 * @return an appropriately configured {@link PDFAValidator} instance.
-		 */
+	/**
+	 * Obtain a new {@link PDFAValidator} instance.
+	 *
+	 * @param config
+	 *            a {@link ValidatorConfig} instance used to configure the
+	 *            {@link PDFAValidator}
+	 * @return an appropriately configured {@link PDFAValidator} instance.
+	 */
 	public PDFAValidator createValidator(ValidatorConfig config);
 
 	/**
@@ -168,7 +168,9 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int viewFails);
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess);
+
+	public PDFAValidator createValidator(PDFAFlavour flavour, boolean logSuccess, int maxCheckedDetailsPerRule);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
@@ -184,7 +186,9 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int viewFails);
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess);
+
+	public PDFAValidator createValidator(ValidationProfile profile, boolean logSuccess, int maxCheckedDetailsPerRule);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -203,7 +207,9 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int viewFails, int maxFailures);
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxFailures);
+
+	public PDFAValidator createFailFastValidator(PDFAFlavour flavour, int maxCheckedDetailsPerRule, int maxFailures);
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -221,7 +227,9 @@ public interface VeraPDFFoundry extends Component {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public PDFAValidator createFailFastValidator(ValidationProfile profile, int viewFails, int maxFailures);
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxFailures);
+
+	public PDFAValidator createFailFastValidator(ValidationProfile profile, int maxCheckedDetailsPerRule, int maxFailures);
 
 	/**
 	 * Obtain a new {@link MetadataFixer} instance.

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
@@ -28,7 +28,7 @@ import org.verapdf.pdfa.validation.profiles.ProfileDetails;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Created as the result of validating a PDF/A document against a
@@ -81,7 +81,7 @@ public interface ValidationResult {
     /**
      * @return the list of {@link TestAssertion}s made during PDF/A validation
      */
-    public Set<TestAssertion> getTestAssertions();
+    public List<TestAssertion> getTestAssertions();
 
     /**
      * @return validation profile which has been used for generating validation result

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -35,10 +35,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -54,27 +54,27 @@ final class ValidationResultImpl implements ValidationResult {
 	private final int totalAssertions;
 	@XmlElementWrapper
 	@XmlElement(name = "assertion")
-	private final Set<TestAssertion> assertions;
+	private final List<TestAssertion> assertions;
 	@XmlAttribute
 	private final boolean isCompliant;
 
 	private final ValidationProfile validationProfile;
 
 	private ValidationResultImpl() {
-		this(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(),
+		this(Profiles.defaultProfile(), Collections.<TestAssertion>emptyList(),
 				false);
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-								 final Set<TestAssertion> assertions, final boolean isCompliant) {
+								 final List<TestAssertion> assertions, final boolean isCompliant) {
 		this(validationProfile, assertions, isCompliant, assertions.size());
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-								 final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
+								 final List<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
 		super();
 		this.flavour = validationProfile.getPDFAFlavour();
-		this.assertions = new HashSet<>(assertions);
+		this.assertions = new ArrayList<>(assertions);
 		this.isCompliant = isCompliant;
 		this.totalAssertions = totalAssertions;
 		this.profileDetails = validationProfile.getDetails();
@@ -117,8 +117,8 @@ final class ValidationResultImpl implements ValidationResult {
 	 * { @inheritDoc }
 	 */
 	@Override
-	public Set<TestAssertion> getTestAssertions() {
-		return Collections.unmodifiableSet(this.assertions);
+	public List<TestAssertion> getTestAssertions() {
+		return Collections.unmodifiableList(this.assertions);
 	}
 
 	/**
@@ -185,27 +185,27 @@ final class ValidationResultImpl implements ValidationResult {
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
-										   final Map<RuleId, Set<TestAssertion>> assertions, final boolean isCompliant, final int totalChecks) {
-		Set<TestAssertion> setAssertions = new HashSet<>();
-		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
+                                           final Map<RuleId, List<TestAssertion>> assertions, final boolean isCompliant, final int totalChecks) {
+		List<TestAssertion> setAssertions = new ArrayList<>();
+		for(List<TestAssertion> ruleAssertions : assertions.values()) {
 			setAssertions.addAll(ruleAssertions);
 		}
 		return new ValidationResultImpl(validationProfile, setAssertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
-										   final Set<TestAssertion> assertions, final boolean isCompliant, final int totalChecks) {
+										   final List<TestAssertion> assertions, final boolean isCompliant, final int totalChecks) {
 		return new ValidationResultImpl(validationProfile, assertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValidationResult(ValidationResult toConvert) {
-		Set<TestAssertion> assertions = toConvert.getTestAssertions();
+		List<TestAssertion> assertions = toConvert.getTestAssertions();
 		return fromValues(toConvert.getValidationProfile(), assertions,
 				toConvert.isCompliant(), toConvert.getTotalAssertions());
 	}
 
 	static ValidationResultImpl stripPassedTests(ValidationResult toStrip) {
-		Set<TestAssertion> assertions = toStrip.getTestAssertions();
+		List<TestAssertion> assertions = toStrip.getTestAssertions();
 		return fromValues(toStrip.getValidationProfile(), stripPassedTests(assertions),
 				toStrip.isCompliant(), toStrip.getTotalAssertions());
 	}
@@ -222,8 +222,8 @@ final class ValidationResultImpl implements ValidationResult {
 		}
 	}
 
-	static Set<TestAssertion> stripPassedTests(final Set<TestAssertion> toStrip) {
-		Set<TestAssertion> strippedSet = new HashSet<>();
+	static List<TestAssertion> stripPassedTests(final List<TestAssertion> toStrip) {
+		List<TestAssertion> strippedSet = new ArrayList<>();
 		for (TestAssertion test : toStrip) {
 			if (test.getStatus() != Status.PASSED)
 				strippedSet.add(test);

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- *
+ * 
  */
 package org.verapdf.pdfa.results;
 
@@ -66,12 +66,12 @@ final class ValidationResultImpl implements ValidationResult {
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-								 final Set<TestAssertion> assertions, final boolean isCompliant) {
+			final Set<TestAssertion> assertions, final boolean isCompliant) {
 		this(validationProfile, assertions, isCompliant, assertions.size());
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-								 final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
+			final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
 		super();
 		this.flavour = validationProfile.getPDFAFlavour();
 		this.assertions = new HashSet<>(assertions);
@@ -186,11 +186,11 @@ final class ValidationResultImpl implements ValidationResult {
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
 										   final Map<RuleId, Set<TestAssertion>> assertions, final boolean isCompliant, final int totalChecks) {
-		Set<TestAssertion> setAssertions = new HashSet<>();
-		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
-			setAssertions.addAll(ruleAssertions);
+		Set<TestAssertion> allAssertions = new HashSet<>();
+		for(Set<TestAssertion> setAssertion : assertions.values()) {
+			allAssertions.addAll(setAssertion);
 		}
-		return new ValidationResultImpl(validationProfile, setAssertions, isCompliant, totalChecks);
+		return new ValidationResultImpl(validationProfile, allAssertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- * 
+ *
  */
 package org.verapdf.pdfa.results;
 
@@ -66,12 +66,12 @@ final class ValidationResultImpl implements ValidationResult {
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-			final Set<TestAssertion> assertions, final boolean isCompliant) {
+								 final Set<TestAssertion> assertions, final boolean isCompliant) {
 		this(validationProfile, assertions, isCompliant, assertions.size());
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-			final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
+								 final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
 		super();
 		this.flavour = validationProfile.getPDFAFlavour();
 		this.assertions = new HashSet<>(assertions);
@@ -186,11 +186,11 @@ final class ValidationResultImpl implements ValidationResult {
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
 										   final Map<RuleId, Set<TestAssertion>> assertions, final boolean isCompliant, final int totalChecks) {
-		Set<TestAssertion> allAssertions = new HashSet<>();
-		for(Set<TestAssertion> setAssertion : assertions.values()) {
-			allAssertions.addAll(setAssertion);
+		Set<TestAssertion> setAssertions = new HashSet<>();
+		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
+			setAssertions.addAll(ruleAssertions);
 		}
-		return new ValidationResultImpl(validationProfile, allAssertions, isCompliant, totalChecks);
+		return new ValidationResultImpl(validationProfile, setAssertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -27,6 +27,7 @@ import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.results.TestAssertion.Status;
 import org.verapdf.pdfa.validation.profiles.ProfileDetails;
 import org.verapdf.pdfa.validation.profiles.Profiles;
+import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.annotation.XmlAttribute;
@@ -36,6 +37,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -180,6 +182,15 @@ final class ValidationResultImpl implements ValidationResult {
 
 	static ValidationResultImpl defaultInstance() {
 		return DEFAULT;
+	}
+
+	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
+										   final Map<RuleId, Set<TestAssertion>> assertions, final boolean isCompliant, final int totalChecks) {
+		Set<TestAssertion> allAssertions = new HashSet<>();
+		for(Set<TestAssertion> setAssertion : assertions.values()) {
+			allAssertions.addAll(setAssertion);
+		}
+		return new ValidationResultImpl(validationProfile, allAssertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -29,8 +29,8 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.JAXBException;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -55,7 +55,7 @@ public class ValidationResults {
 	 *            compliant with the indicated flavour
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, List<TestAssertion>> assertions,
 													final boolean isCompliant) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -76,7 +76,7 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, List<TestAssertion>> assertions,
 													final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -93,16 +93,17 @@ public class ValidationResults {
 	 *            the Set of TestAssertions reported by during validation
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions) {
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile,
+                                                    final Map<RuleId, List<TestAssertion>> assertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
 		if (assertions == null)
 			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
 		boolean isCompliant = true;
-		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
+		for(List<TestAssertion> assertionsPerRule : assertions.values()) {
 			if(!isCompliant)
 				break;
-			for (TestAssertion assertion : ruleAssertions) {
+			for (TestAssertion assertion : assertionsPerRule) {
 				if (assertion.getStatus() == Status.FAILED) {
 					isCompliant = false;
 					break;

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- * 
+ *
  */
 package org.verapdf.pdfa.results;
 
@@ -29,7 +29,6 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.JAXBException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -77,8 +76,8 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
-			final boolean isCompliant, final int totalAssertions) {
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, Map<RuleId, Set<TestAssertion>> assertions,
+													final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
 		if (assertions == null)
@@ -100,8 +99,10 @@ public class ValidationResults {
 		if (assertions == null)
 			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
 		boolean isCompliant = true;
-		for(Set<TestAssertion> setAssertions : assertions.values()) {
-			for(TestAssertion assertion : setAssertions) {
+		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
+			if(!isCompliant)
+				break;
+			for (TestAssertion assertion : ruleAssertions) {
 				if (assertion.getStatus() == Status.FAILED) {
 					isCompliant = false;
 					break;
@@ -135,7 +136,7 @@ public class ValidationResults {
 	/**
 	 * Creates an immutable TestAssertion instance from the passed parameter
 	 * values.
-	 * 
+	 *
 	 * @param ordinal
 	 *            the integer ordinal for the instance
 	 * @param ruleId
@@ -153,7 +154,7 @@ public class ValidationResults {
 	 *         values
 	 */
 	public static TestAssertion assertionFromValues(final int ordinal, final RuleId ruleId, final Status status,
-			final String message, final Location location) {
+													final String message, final Location location) {
 		return TestAssertionImpl.fromValues(ordinal, ruleId, status, message, location);
 	}
 
@@ -172,7 +173,7 @@ public class ValidationResults {
 	/**
 	 * TODO: Better explanation of level and context. Creates an immutable
 	 * {@link Location} instance.
-	 * 
+	 *
 	 * @param level
 	 *            the Locations level, represented as a String
 	 * @param context
@@ -201,7 +202,7 @@ public class ValidationResults {
 	 * {@code assertion.getStatus() == TestAssertion.Status.PASSED} from
 	 * {@code toStrip} and returns a new {@link ValidationResult} without the
 	 * passed assertions.
-	 * 
+	 *
 	 * @param toStrip
 	 *            a {@code ValidationResult} to clone without passed
 	 *            {@code TestAssertion}s

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -29,6 +29,8 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.JAXBException;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -54,7 +56,7 @@ public class ValidationResults {
 	 *            compliant with the indicated flavour
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
 													final boolean isCompliant) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -75,7 +77,7 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
 			final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -92,16 +94,18 @@ public class ValidationResults {
 	 *            the Set of TestAssertions reported by during validation
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions) {
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
 		if (assertions == null)
 			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
 		boolean isCompliant = true;
-		for (TestAssertion assertion : assertions) {
-			if (assertion.getStatus() == Status.FAILED) {
-				isCompliant = false;
-				break;
+		for(Set<TestAssertion> setAssertions : assertions.values()) {
+			for(TestAssertion assertion : setAssertions) {
+				if (assertion.getStatus() == Status.FAILED) {
+					isCompliant = false;
+					break;
+				}
 			}
 		}
 		return resultFromValues(validationProfile, assertions, isCompliant);

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- *
+ * 
  */
 package org.verapdf.pdfa.results;
 
@@ -29,6 +29,7 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.JAXBException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -76,8 +77,8 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, Map<RuleId, Set<TestAssertion>> assertions,
-													final boolean isCompliant, final int totalAssertions) {
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
+			final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
 		if (assertions == null)
@@ -99,10 +100,8 @@ public class ValidationResults {
 		if (assertions == null)
 			throw new NullPointerException(ASSERTIONS_NOT_NULL_MESSAGE);
 		boolean isCompliant = true;
-		for(Set<TestAssertion> ruleAssertions : assertions.values()) {
-			if(!isCompliant)
-				break;
-			for (TestAssertion assertion : ruleAssertions) {
+		for(Set<TestAssertion> setAssertions : assertions.values()) {
+			for(TestAssertion assertion : setAssertions) {
 				if (assertion.getStatus() == Status.FAILED) {
 					isCompliant = false;
 					break;
@@ -136,7 +135,7 @@ public class ValidationResults {
 	/**
 	 * Creates an immutable TestAssertion instance from the passed parameter
 	 * values.
-	 *
+	 * 
 	 * @param ordinal
 	 *            the integer ordinal for the instance
 	 * @param ruleId
@@ -154,7 +153,7 @@ public class ValidationResults {
 	 *         values
 	 */
 	public static TestAssertion assertionFromValues(final int ordinal, final RuleId ruleId, final Status status,
-													final String message, final Location location) {
+			final String message, final Location location) {
 		return TestAssertionImpl.fromValues(ordinal, ruleId, status, message, location);
 	}
 
@@ -173,7 +172,7 @@ public class ValidationResults {
 	/**
 	 * TODO: Better explanation of level and context. Creates an immutable
 	 * {@link Location} instance.
-	 *
+	 * 
 	 * @param level
 	 *            the Locations level, represented as a String
 	 * @param context
@@ -202,7 +201,7 @@ public class ValidationResults {
 	 * {@code assertion.getStatus() == TestAssertion.Status.PASSED} from
 	 * {@code toStrip} and returns a new {@link ValidationResult} without the
 	 * passed assertions.
-	 *
+	 * 
 	 * @param toStrip
 	 *            a {@code ValidationResult} to clone without passed
 	 *            {@code TestAssertion}s

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -76,7 +76,7 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, Map<RuleId, Set<TestAssertion>> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Map<RuleId, Set<TestAssertion>> assertions,
 													final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
@@ -70,8 +70,19 @@ class BaseValidator implements PDFAValidator {
 
 	protected String rootType;
 
+	protected BaseValidator(final ValidationProfile profile) {
+		this(profile, false, -1);
+	}
+
 	protected BaseValidator(final ValidationProfile profile, final int maxCheckedDetailsPerRule) {
 		this(profile, false, maxCheckedDetailsPerRule);
+	}
+
+	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests) {
+		super();
+		this.profile = profile;
+		this.logPassedTests = logPassedTests;
+		this.maxCheckedDetailsPerRule = -1;
 	}
 
 	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests, final int maxCheckedDetailsPerRule) {
@@ -301,6 +312,7 @@ class BaseValidator implements PDFAValidator {
 					}
 				} else {
 					List<TestAssertion> assertionsList = new ArrayList<>();
+					assertionsList.add(assertion);
 					results.put(assertion.getRuleId(), assertionsList);
 				}
 			}

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
@@ -49,6 +49,7 @@ import java.util.*;
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 class BaseValidator implements PDFAValidator {
+	private static final int MAX_OF_EQUAL_TYPE_RULES_ISSUES = 100;
 	private static final URI componentId = URI.create("http://pdfa.verapdf.org/validators#default");
 	private static final String componentName = "veraPDF PDF/A Validator";
 	private static final ComponentDetails componentDetails = Components.libraryDetails(componentId, componentName);
@@ -58,10 +59,9 @@ class BaseValidator implements PDFAValidator {
 	private final Deque<Object> objectsStack = new ArrayDeque<>();
 	private final Deque<String> objectsContext = new ArrayDeque<>();
 	private final Map<Rule, List<ObjectWithContext>> deferredRules = new HashMap<>();
+//	protected final Set<TestAssertion> results = new HashSet<>();
 	protected final Map<RuleId, Set<TestAssertion>> results = new HashMap<>();
 	protected int testCounter = 0;
-	protected int displayedFailuresCounter;
-	protected int failureCount = 0;
 	protected boolean abortProcessing = false;
 	protected final boolean logPassedTests;
 	protected boolean isCompliant = true;
@@ -70,15 +70,14 @@ class BaseValidator implements PDFAValidator {
 
 	protected String rootType;
 
-	protected BaseValidator(final ValidationProfile profile, final int displayedFailuresCounter) {
-		this(profile, false, displayedFailuresCounter);
+	protected BaseValidator(final ValidationProfile profile) {
+		this(profile, false);
 	}
 
-	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests, final int displayedFailuresCounter) {
+	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests) {
 		super();
 		this.profile = profile;
 		this.logPassedTests = logPassedTests;
-		this.displayedFailuresCounter = displayedFailuresCounter;
 	}
 
 	/*
@@ -289,18 +288,13 @@ class BaseValidator implements PDFAValidator {
 			Location location = ValidationResults.locationFromValues(this.rootType, locationContext);
 			TestAssertion assertion = ValidationResults.assertionFromValues(this.testCounter, rule.getRuleId(),
 					assertionResult ? Status.PASSED : Status.FAILED, rule.getDescription(), location);
-			if (this.isCompliant)
+			if (this.isCompliant) {
 				this.isCompliant = assertionResult;
+			}
 			if (!assertionResult || this.logPassedTests) {
-				failureCount++;
-				if(failureCount < displayedFailuresCounter) {
-					if (results.containsKey(assertion.getRuleId())) {
-						this.results.get(assertion.getRuleId()).add(assertion);
-					} else {
-						Set<TestAssertion> assertionSet = new HashSet<>();
-						assertionSet.add(assertion);
-						this.results.put(assertion.getRuleId(), assertionSet);
-					}
+				Set<TestAssertion> resultSet = this.results.get(assertion.getRuleId());
+				if(resultSet.size() < MAX_OF_EQUAL_TYPE_RULES_ISSUES) {
+					resultSet.add(assertion);
 				}
 			}
 		}

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
@@ -49,7 +49,6 @@ import java.util.*;
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 class BaseValidator implements PDFAValidator {
-	private static final int MAX_OF_EQUAL_TYPE_RULES_ISSUES = 100;
 	private static final URI componentId = URI.create("http://pdfa.verapdf.org/validators#default");
 	private static final String componentName = "veraPDF PDF/A Validator";
 	private static final ComponentDetails componentDetails = Components.libraryDetails(componentId, componentName);
@@ -59,9 +58,10 @@ class BaseValidator implements PDFAValidator {
 	private final Deque<Object> objectsStack = new ArrayDeque<>();
 	private final Deque<String> objectsContext = new ArrayDeque<>();
 	private final Map<Rule, List<ObjectWithContext>> deferredRules = new HashMap<>();
-//	protected final Set<TestAssertion> results = new HashSet<>();
 	protected final Map<RuleId, Set<TestAssertion>> results = new HashMap<>();
 	protected int testCounter = 0;
+	protected int displayedFailuresCounter;
+	protected int failureCount = 0;
 	protected boolean abortProcessing = false;
 	protected final boolean logPassedTests;
 	protected boolean isCompliant = true;
@@ -70,14 +70,15 @@ class BaseValidator implements PDFAValidator {
 
 	protected String rootType;
 
-	protected BaseValidator(final ValidationProfile profile) {
-		this(profile, false);
+	protected BaseValidator(final ValidationProfile profile, final int displayedFailuresCounter) {
+		this(profile, false, displayedFailuresCounter);
 	}
 
-	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests) {
+	protected BaseValidator(final ValidationProfile profile, final boolean logPassedTests, final int displayedFailuresCounter) {
 		super();
 		this.profile = profile;
 		this.logPassedTests = logPassedTests;
+		this.displayedFailuresCounter = displayedFailuresCounter;
 	}
 
 	/*
@@ -288,13 +289,18 @@ class BaseValidator implements PDFAValidator {
 			Location location = ValidationResults.locationFromValues(this.rootType, locationContext);
 			TestAssertion assertion = ValidationResults.assertionFromValues(this.testCounter, rule.getRuleId(),
 					assertionResult ? Status.PASSED : Status.FAILED, rule.getDescription(), location);
-			if (this.isCompliant) {
+			if (this.isCompliant)
 				this.isCompliant = assertionResult;
-			}
 			if (!assertionResult || this.logPassedTests) {
-				Set<TestAssertion> resultSet = this.results.get(assertion.getRuleId());
-				if(resultSet.size() < MAX_OF_EQUAL_TYPE_RULES_ISSUES) {
-					resultSet.add(assertion);
+				failureCount++;
+				if(failureCount < displayedFailuresCounter) {
+					if (results.containsKey(assertion.getRuleId())) {
+						this.results.get(assertion.getRuleId()).add(assertion);
+					} else {
+						Set<TestAssertion> assertionSet = new HashSet<>();
+						assertionSet.add(assertion);
+						this.results.put(assertion.getRuleId(), assertionSet);
+					}
 				}
 			}
 		}

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
@@ -38,9 +38,19 @@ class FastFailValidator extends BaseValidator {
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
+                                final boolean logPassedTests) {
+        this(profile, logPassedTests, -1, 0);
+    }
+
+    /**
+     * @param profile
+     * @param logPassedTests
+     */
+    protected FastFailValidator(final ValidationProfile profile,
                                 final boolean logPassedTests,
-                                final int maxCheckedDetailsPerRule) {
-        this(profile, logPassedTests, maxCheckedDetailsPerRule, 0);
+                                final int maxFailedTests) {
+        super(profile, logPassedTests, -1);
+        this.maxFailedTests = maxFailedTests;
     }
 
     /**

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
@@ -2,16 +2,16 @@
  * This file is part of veraPDF Library core, a module of the veraPDF project.
  * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
  * All rights reserved.
- *
+ * <p>
  * veraPDF Library core is free software: you can redistribute it and/or modify
  * it under the terms of either:
- *
+ * <p>
  * The GNU General public license GPLv3+.
  * You should have received a copy of the GNU General Public License
  * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
  * tree.  If not, see http://www.gnu.org/licenses/ or
  * https://www.gnu.org/licenses/gpl-3.0.en.html.
- *
+ * <p>
  * The Mozilla Public License MPLv2+.
  * You should have received a copy of the Mozilla Public License along with
  * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- * 
+ *
  */
 package org.verapdf.pdfa.validation.validators;
 
@@ -28,19 +28,18 @@ import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
- *
  */
 class FastFailValidator extends BaseValidator {
-    private final int maxFailedTests;
-    protected int failureCount = 0;
+    private final int maxFailedTestsForRule;
 
     /**
      * @param profile
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
-            final boolean logPassedTests) {
-        this(profile, logPassedTests, 0);
+                                final boolean logPassedTests,
+                                final int displayedFailuresCounter) {
+        this(profile, logPassedTests, 0, displayedFailuresCounter);
     }
 
     /**
@@ -48,20 +47,20 @@ class FastFailValidator extends BaseValidator {
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
-            final boolean logPassedTests, final int maxFailedTests) {
-        super(profile, logPassedTests);
-        this.maxFailedTests = maxFailedTests;
+                                final boolean logPassedTests, final int maxFailedTestsForRule,
+                                final int displayedFailuresCounter) {
+        super(profile, logPassedTests, displayedFailuresCounter);
+        this.maxFailedTestsForRule = maxFailedTestsForRule;
     }
 
     @Override
     protected void processAssertionResult(final boolean assertionResult,
-            final String locationContext, final Rule rule) {
+                                          final String locationContext, final Rule rule) {
         super.processAssertionResult(assertionResult, locationContext, rule);
-        if (!assertionResult) {
-            this.failureCount++;
-            if ((this.maxFailedTests > 0) && (this.failureCount >= this.maxFailedTests)) {
-                this.abortProcessing = true;
-            }
+        if (!assertionResult && this.maxFailedTestsForRule > 0
+                && (this.results.containsKey(rule.getRuleId())
+                && this.results.get(rule.getRuleId()).size() >= maxFailedTestsForRule)) {
+            this.abortProcessing = true;
         }
     }
 

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
@@ -2,16 +2,16 @@
  * This file is part of veraPDF Library core, a module of the veraPDF project.
  * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
  * All rights reserved.
- * <p>
+ *
  * veraPDF Library core is free software: you can redistribute it and/or modify
  * it under the terms of either:
- * <p>
+ *
  * The GNU General public license GPLv3+.
  * You should have received a copy of the GNU General Public License
  * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
  * tree.  If not, see http://www.gnu.org/licenses/ or
  * https://www.gnu.org/licenses/gpl-3.0.en.html.
- * <p>
+ *
  * The Mozilla Public License MPLv2+.
  * You should have received a copy of the Mozilla Public License along with
  * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
@@ -30,7 +30,8 @@ import org.verapdf.pdfa.validation.profiles.ValidationProfile;
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 class FastFailValidator extends BaseValidator {
-    private final int maxFailedTestsForRule;
+    private final int maxFailedTests;
+    protected int failureCount = 0;
 
     /**
      * @param profile
@@ -38,8 +39,8 @@ class FastFailValidator extends BaseValidator {
      */
     protected FastFailValidator(final ValidationProfile profile,
                                 final boolean logPassedTests,
-                                final int displayedFailuresCounter) {
-        this(profile, logPassedTests, 0, displayedFailuresCounter);
+                                final int maxCheckedDetailsPerRule) {
+        this(profile, logPassedTests, maxCheckedDetailsPerRule, 0);
     }
 
     /**
@@ -47,20 +48,22 @@ class FastFailValidator extends BaseValidator {
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
-                                final boolean logPassedTests, final int maxFailedTestsForRule,
-                                final int displayedFailuresCounter) {
-        super(profile, logPassedTests, displayedFailuresCounter);
-        this.maxFailedTestsForRule = maxFailedTestsForRule;
+                                final boolean logPassedTests,
+                                final int maxCheckedDetailsPerRule,
+                                final int maxFailedTests) {
+        super(profile, logPassedTests, maxCheckedDetailsPerRule);
+        this.maxFailedTests = maxFailedTests;
     }
 
     @Override
     protected void processAssertionResult(final boolean assertionResult,
                                           final String locationContext, final Rule rule) {
         super.processAssertionResult(assertionResult, locationContext, rule);
-        if (!assertionResult && this.maxFailedTestsForRule > 0
-                && (this.results.containsKey(rule.getRuleId())
-                && this.results.get(rule.getRuleId()).size() >= maxFailedTestsForRule)) {
-            this.abortProcessing = true;
+        if (!assertionResult) {
+            this.failureCount++;
+            if ((this.maxFailedTests > 0) && (this.failureCount >= this.maxFailedTests)) {
+                this.abortProcessing = true;
+            }
         }
     }
 

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/FastFailValidator.java
@@ -2,16 +2,16 @@
  * This file is part of veraPDF Library core, a module of the veraPDF project.
  * Copyright (c) 2015, veraPDF Consortium <info@verapdf.org>
  * All rights reserved.
- * <p>
+ *
  * veraPDF Library core is free software: you can redistribute it and/or modify
  * it under the terms of either:
- * <p>
+ *
  * The GNU General public license GPLv3+.
  * You should have received a copy of the GNU General Public License
  * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
  * tree.  If not, see http://www.gnu.org/licenses/ or
  * https://www.gnu.org/licenses/gpl-3.0.en.html.
- * <p>
+ *
  * The Mozilla Public License MPLv2+.
  * You should have received a copy of the Mozilla Public License along with
  * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- *
+ * 
  */
 package org.verapdf.pdfa.validation.validators;
 
@@ -28,18 +28,19 @@ import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
+ *
  */
 class FastFailValidator extends BaseValidator {
-    private final int maxFailedTestsForRule;
+    private final int maxFailedTests;
+    protected int failureCount = 0;
 
     /**
      * @param profile
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
-                                final boolean logPassedTests,
-                                final int displayedFailuresCounter) {
-        this(profile, logPassedTests, 0, displayedFailuresCounter);
+            final boolean logPassedTests) {
+        this(profile, logPassedTests, 0);
     }
 
     /**
@@ -47,20 +48,20 @@ class FastFailValidator extends BaseValidator {
      * @param logPassedTests
      */
     protected FastFailValidator(final ValidationProfile profile,
-                                final boolean logPassedTests, final int maxFailedTestsForRule,
-                                final int displayedFailuresCounter) {
-        super(profile, logPassedTests, displayedFailuresCounter);
-        this.maxFailedTestsForRule = maxFailedTestsForRule;
+            final boolean logPassedTests, final int maxFailedTests) {
+        super(profile, logPassedTests);
+        this.maxFailedTests = maxFailedTests;
     }
 
     @Override
     protected void processAssertionResult(final boolean assertionResult,
-                                          final String locationContext, final Rule rule) {
+            final String locationContext, final Rule rule) {
         super.processAssertionResult(assertionResult, locationContext, rule);
-        if (!assertionResult && this.maxFailedTestsForRule > 0
-                && (this.results.containsKey(rule.getRuleId())
-                && this.results.get(rule.getRuleId()).size() >= maxFailedTestsForRule)) {
-            this.abortProcessing = true;
+        if (!assertionResult) {
+            this.failureCount++;
+            if ((this.maxFailedTests > 0) && (this.failureCount >= this.maxFailedTests)) {
+                this.abortProcessing = true;
+            }
         }
     }
 

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
@@ -46,7 +46,7 @@ public interface ValidatorConfig {
 	public boolean isRecordPasses();
 
 	/**
-	 * The maximum number of failed validation checks encountered before
+	 * The maximum number of failed validation checks encountered for the one rule before
 	 * validation is terminated.
 	 * 
 	 * @return the number of failed validation checks before validation is
@@ -60,4 +60,11 @@ public interface ValidatorConfig {
 	 * @return the {@link PDFAFlavour} that the validator enforces.
 	 */
 	public PDFAFlavour getFlavour();
+
+	/**
+	 * The maximum number of fails that should be saved to show them to user.
+	 *
+	 * @return the number of fails that should be saved to show them to user
+	 */
+	public int getViewFails();
 }

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
@@ -66,5 +66,5 @@ public interface ValidatorConfig {
 	 *
 	 * @return the number of fails that should be saved to show them to user
 	 */
-	public int getViewFails();
+	public int getMaxCheckedDetailsPerRule();
 }

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
@@ -46,9 +46,9 @@ public interface ValidatorConfig {
 	public boolean isRecordPasses();
 
 	/**
-	 * The maximum number of failed validation checks encountered before
+	 * The maximum number of failed validation checks encountered for the one rule before
 	 * validation is terminated.
-	 * 
+	 *
 	 * @return the number of failed validation checks before validation is
 	 *         terminated.
 	 */
@@ -56,8 +56,15 @@ public interface ValidatorConfig {
 
 	/**
 	 * Obtain the particular PDF/A specification that the validator enforces.
-	 * 
+	 *
 	 * @return the {@link PDFAFlavour} that the validator enforces.
 	 */
 	public PDFAFlavour getFlavour();
+
+	/**
+	 * The maximum number of fails that should be saved to show them to user.
+	 *
+	 * @return the number of fails that should be saved to show them to user
+	 */
+	public int getViewFails();
 }

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfig.java
@@ -46,7 +46,7 @@ public interface ValidatorConfig {
 	public boolean isRecordPasses();
 
 	/**
-	 * The maximum number of failed validation checks encountered for the one rule before
+	 * The maximum number of failed validation checks encountered before
 	 * validation is terminated.
 	 * 
 	 * @return the number of failed validation checks before validation is
@@ -60,11 +60,4 @@ public interface ValidatorConfig {
 	 * @return the {@link PDFAFlavour} that the validator enforces.
 	 */
 	public PDFAFlavour getFlavour();
-
-	/**
-	 * The maximum number of fails that should be saved to show them to user.
-	 *
-	 * @return the number of fails that should be saved to show them to user
-	 */
-	public int getViewFails();
 }

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -43,19 +43,16 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@XmlAttribute
 	private final boolean recordPasses;
 	@XmlAttribute
-	private final int viewFails;
-	@XmlAttribute
 	private final int maxFails;
 
 	private ValidatorConfigImpl() {
-		this(PDFAFlavour.NO_FLAVOUR, false, -1, -1);
+		this(PDFAFlavour.NO_FLAVOUR, false, -1);
 	}
 
-	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
+	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
 		super();
 		this.flavour = flavour;
 		this.recordPasses = recordPasses;
-		this.viewFails = viewFails;
 		this.maxFails = maxFails;
 	}
 
@@ -81,11 +78,6 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@Override
 	public PDFAFlavour getFlavour() {
 		return this.flavour;
-	}
-
-	@Override
-	public int getViewFails() {
-		return this.viewFails;
 	}
 
 	/**
@@ -133,20 +125,16 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	 */
 	@Override
 	public String toString() {
-		return "ValidatorConfigImpl{" +
-				"flavour=" + flavour +
-				", recordPasses=" + recordPasses +
-				", viewFails=" + viewFails +
-				", maxFails=" + maxFails +
-				'}';
+		return "ValidatorConfigImpl [recordPasses=" + this.recordPasses + ", maxFails=" + this.maxFails + ", flavour="
+				+ this.flavour + "]";
 	}
 
 	static ValidatorConfig defaultInstance() {
 		return defaultConfig;
 	}
 
-	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
-		return new ValidatorConfigImpl(flavour, recordPasses, viewFails, maxFails);
+	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
+		return new ValidatorConfigImpl(flavour, recordPasses, maxFails);
 	}
 
 	static class Adapter extends XmlAdapter<ValidatorConfigImpl, ValidatorConfig> {

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -43,19 +43,19 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@XmlAttribute
 	private final boolean recordPasses;
 	@XmlAttribute
-	private final int viewFails;
+	private final int maxCheckedDetailsPerRule;
 	@XmlAttribute
 	private final int maxFails;
 
 	private ValidatorConfigImpl() {
-		this(PDFAFlavour.NO_FLAVOUR, false, 100, -1);
+		this(PDFAFlavour.NO_FLAVOUR, false, -1, -1);
 	}
 
-	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
+	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int maxCheckedDetailsPerRule, final int maxFails) {
 		super();
 		this.flavour = flavour;
 		this.recordPasses = recordPasses;
-		this.viewFails = viewFails;
+		this.maxCheckedDetailsPerRule = maxCheckedDetailsPerRule;
 		this.maxFails = maxFails;
 	}
 
@@ -84,8 +84,8 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	}
 
 	@Override
-	public int getViewFails() {
-		return this.viewFails;
+	public int getMaxCheckedDetailsPerRule() {
+		return this.maxCheckedDetailsPerRule;
 	}
 
 	/**
@@ -136,7 +136,7 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 		return "ValidatorConfigImpl{" +
 				"flavour=" + flavour +
 				", recordPasses=" + recordPasses +
-				", viewFails=" + viewFails +
+				", maxCheckedDetailsPerRule=" + maxCheckedDetailsPerRule +
 				", maxFails=" + maxFails +
 				'}';
 	}
@@ -147,6 +147,10 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 
 	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
 		return new ValidatorConfigImpl(flavour, recordPasses, viewFails, maxFails);
+	}
+
+	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
+		return new ValidatorConfigImpl(flavour, recordPasses, -1, maxFails);
 	}
 
 	static class Adapter extends XmlAdapter<ValidatorConfigImpl, ValidatorConfig> {

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -43,16 +43,19 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@XmlAttribute
 	private final boolean recordPasses;
 	@XmlAttribute
+	private final int viewFails;
+	@XmlAttribute
 	private final int maxFails;
 
 	private ValidatorConfigImpl() {
-		this(PDFAFlavour.NO_FLAVOUR, false, -1);
+		this(PDFAFlavour.NO_FLAVOUR, false, -1, -1);
 	}
 
-	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
+	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
 		super();
 		this.flavour = flavour;
 		this.recordPasses = recordPasses;
+		this.viewFails = viewFails;
 		this.maxFails = maxFails;
 	}
 
@@ -78,6 +81,11 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@Override
 	public PDFAFlavour getFlavour() {
 		return this.flavour;
+	}
+
+	@Override
+	public int getViewFails() {
+		return this.viewFails;
 	}
 
 	/**
@@ -125,16 +133,20 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	 */
 	@Override
 	public String toString() {
-		return "ValidatorConfigImpl [recordPasses=" + this.recordPasses + ", maxFails=" + this.maxFails + ", flavour="
-				+ this.flavour + "]";
+		return "ValidatorConfigImpl{" +
+				"flavour=" + flavour +
+				", recordPasses=" + recordPasses +
+				", viewFails=" + viewFails +
+				", maxFails=" + maxFails +
+				'}';
 	}
 
 	static ValidatorConfig defaultInstance() {
 		return defaultConfig;
 	}
 
-	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
-		return new ValidatorConfigImpl(flavour, recordPasses, maxFails);
+	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
+		return new ValidatorConfigImpl(flavour, recordPasses, viewFails, maxFails);
 	}
 
 	static class Adapter extends XmlAdapter<ValidatorConfigImpl, ValidatorConfig> {

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -43,16 +43,19 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@XmlAttribute
 	private final boolean recordPasses;
 	@XmlAttribute
+	private final int viewFails;
+	@XmlAttribute
 	private final int maxFails;
 
 	private ValidatorConfigImpl() {
-		this(PDFAFlavour.NO_FLAVOUR, false, -1);
+		this(PDFAFlavour.NO_FLAVOUR, false, 100, -1);
 	}
 
-	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
+	private ValidatorConfigImpl(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
 		super();
 		this.flavour = flavour;
 		this.recordPasses = recordPasses;
+		this.viewFails = viewFails;
 		this.maxFails = maxFails;
 	}
 
@@ -78,6 +81,11 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	@Override
 	public PDFAFlavour getFlavour() {
 		return this.flavour;
+	}
+
+	@Override
+	public int getViewFails() {
+		return this.viewFails;
 	}
 
 	/**
@@ -125,16 +133,20 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	 */
 	@Override
 	public String toString() {
-		return "ValidatorConfigImpl [recordPasses=" + this.recordPasses + ", maxFails=" + this.maxFails + ", flavour="
-				+ this.flavour + "]";
+		return "ValidatorConfigImpl{" +
+				"flavour=" + flavour +
+				", recordPasses=" + recordPasses +
+				", viewFails=" + viewFails +
+				", maxFails=" + maxFails +
+				'}';
 	}
 
 	static ValidatorConfig defaultInstance() {
 		return defaultConfig;
 	}
 
-	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int maxFails) {
-		return new ValidatorConfigImpl(flavour, recordPasses, maxFails);
+	static ValidatorConfig fromValues(final PDFAFlavour flavour, final boolean recordPasses, final int viewFails, final int maxFails) {
+		return new ValidatorConfigImpl(flavour, recordPasses, viewFails, maxFails);
 	}
 
 	static class Adapter extends XmlAdapter<ValidatorConfigImpl, ValidatorConfig> {

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -98,6 +98,7 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 		result = prime * result + ((this.flavour == null) ? 0 : this.flavour.hashCode());
 		result = prime * result + this.maxFails;
 		result = prime * result + (this.recordPasses ? 1231 : 1237);
+		result = prime * result + this.maxCheckedDetailsPerRule;
 		return result;
 	}
 
@@ -123,6 +124,9 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 			return false;
 		}
 		if (this.recordPasses != other.recordPasses) {
+			return false;
+		}
+		if (this.maxCheckedDetailsPerRule != other.maxCheckedDetailsPerRule) {
 			return false;
 		}
 		return true;

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- * 
+ *
  */
 package org.verapdf.pdfa.validation.validators;
 
@@ -36,7 +36,7 @@ import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 /**
  * Static utility class that fills in for a factory for {@link PDFAValidator}s.
- * 
+ *
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 public final class ValidatorFactory {
@@ -51,7 +51,7 @@ public final class ValidatorFactory {
 	 * when offline. A {@link ProfileDirectory} populated with the pre-loaded
 	 * profiles can be obtained by calling
 	 * {@link Profiles#getVeraProfileDirectory()}.
-	 * 
+	 *
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -63,18 +63,20 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final PDFAFlavour flavour, final boolean logPassedChecks) {
+	public static PDFAValidator createValidator(final PDFAFlavour flavour,
+												final boolean logPassedChecks,
+												final int viewFailures) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks);
+				logPassedChecks, viewFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} instance that uses one of the
 	 * {@link ValidationProfile}s packaged as a core library resource, see
 	 * {@link Validators#createValidator(PDFAFlavour, boolean)}.
-	 * 
+	 *
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -93,31 +95,33 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final PDFAFlavour flavour, final boolean logPassedChecks,
-			final int maxFailures) {
+                                                final int viewFailures,
+                                                final int maxFailures) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks, maxFailures);
+				logPassedChecks, viewFailures, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
 	 * and configured NOT to log passed checks.
-	 * 
+	 *
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile) {
-		return createValidator(profile, false);
+	public static PDFAValidator createValidator(final ValidationProfile profile,
+                                                final int viewFailures) {
+		return createValidator(profile, false, viewFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
 	 * and chosen passed test logging.
-	 * 
+	 *
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -128,16 +132,18 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile, final boolean logPassedChecks) {
+	public static PDFAValidator createValidator(final ValidationProfile profile,
+												final boolean logPassedChecks,
+												final int viewFailures) {
 		if (profile == null)
 			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
-		return new BaseValidator(profile, logPassedChecks);
+		return new BaseValidator(profile, logPassedChecks, viewFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * requested fast failing behaviour and configured NOT to log passed checks.
-	 * 
+	 *
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -150,14 +156,16 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile, final int maxFailures) {
-		return createValidator(profile, false, maxFailures);
+	public static PDFAValidator createValidator(final ValidationProfile profile,
+                                                final int viewFailures,
+                                                final int maxFailures) {
+		return createValidator(profile, false, viewFailures, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * requested fast failing behaviour and configured NOT to log passed checks.
-	 * 
+	 *
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -171,14 +179,16 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final PDFAFlavour flavour, final int maxFailures) {
-		return createValidator(flavour, false, maxFailures);
+	public static PDFAValidator createValidator(final PDFAFlavour flavour,
+                                                final int viewFailures,
+                                                final int maxFailures) {
+		return createValidator(flavour, false, viewFailures, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * chosen passed test logging and requested fast failing behaviour.
-	 * 
+	 *
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -195,13 +205,15 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile, final boolean logPassedChecks,
-			final int maxFailures) {
+	public static PDFAValidator createValidator(final ValidationProfile profile,
+                                                final boolean logPassedChecks,
+                                                final int viewFailures,
+                                                final int maxFailures) {
 		if (profile == null)
 			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
 		if (maxFailures > 0)
-			return new FastFailValidator(profile, logPassedChecks, maxFailures);
-		return createValidator(profile, logPassedChecks);
+			return new FastFailValidator(profile, logPassedChecks, viewFailures, maxFailures);
+		return createValidator(profile, logPassedChecks, viewFailures);
 	}
 
 	/**
@@ -213,7 +225,7 @@ public final class ValidatorFactory {
 
 	/**
 	 * Create a {@link ValidatorConfig} instance from the passed values.
-	 * 
+	 *
 	 * @param flavour
 	 *            the {@link PDFAFlavour} used for validation
 	 * @param recordPasses
@@ -226,14 +238,14 @@ public final class ValidatorFactory {
 	 *         values.
 	 */
 	public static ValidatorConfig createConfig(final PDFAFlavour flavour, final boolean recordPasses,
-			final int maxFails) {
-		return ValidatorConfigImpl.fromValues(flavour, recordPasses, maxFails);
+											   final int viewFails, final int maxFails) {
+		return ValidatorConfigImpl.fromValues(flavour, recordPasses, viewFails, maxFails);
 	}
 
 	/**
 	 * De-serialises a {@link ValidatorConfig} instance from it's XML
 	 * representation
-	 * 
+	 *
 	 * @param source
 	 *            an {@link InputStream} that is an XML representation of a
 	 *            {@link ValidatorConfig}
@@ -248,7 +260,7 @@ public final class ValidatorFactory {
 
 	/**
 	 * Serialises a {@link ValidatorConfig} to XML
-	 * 
+	 *
 	 * @param source
 	 *            a {@link ValidatorConfig} instance to serialise
 	 * @return a {@link String} containing the XML representation of the passed
@@ -263,7 +275,7 @@ public final class ValidatorFactory {
 	/**
 	 * Serialises a {@link ValidatorConfig} instance to its XML representation
 	 * that's output to the passed {@link OutputStream}.
-	 * 
+	 *
 	 * @param source
 	 *            the {@link ValidatorConfig} instance to serialise
 	 * @param dest

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
@@ -19,7 +19,7 @@
  * http://mozilla.org/MPL/2.0/.
  */
 /**
- *
+ * 
  */
 package org.verapdf.pdfa.validation.validators;
 
@@ -36,7 +36,7 @@ import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 /**
  * Static utility class that fills in for a factory for {@link PDFAValidator}s.
- *
+ * 
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
  */
 public final class ValidatorFactory {
@@ -51,7 +51,7 @@ public final class ValidatorFactory {
 	 * when offline. A {@link ProfileDirectory} populated with the pre-loaded
 	 * profiles can be obtained by calling
 	 * {@link Profiles#getVeraProfileDirectory()}.
-	 *
+	 * 
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -63,20 +63,18 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final PDFAFlavour flavour,
-												final boolean logPassedChecks,
-												final int viewFailures) {
+	public static PDFAValidator createValidator(final PDFAFlavour flavour, final boolean logPassedChecks) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks, viewFailures);
+				logPassedChecks);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} instance that uses one of the
 	 * {@link ValidationProfile}s packaged as a core library resource, see
 	 * {@link Validators#createValidator(PDFAFlavour, boolean)}.
-	 *
+	 * 
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -95,33 +93,31 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final PDFAFlavour flavour, final boolean logPassedChecks,
-                                                final int viewFailures,
-                                                final int maxFailures) {
+			final int maxFailures) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks, viewFailures, maxFailures);
+				logPassedChecks, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
 	 * and configured NOT to log passed checks.
-	 *
+	 * 
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
-                                                final int viewFailures) {
-		return createValidator(profile, false, viewFailures);
+	public static PDFAValidator createValidator(final ValidationProfile profile) {
+		return createValidator(profile, false);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile
 	 * and chosen passed test logging.
-	 *
+	 * 
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -132,18 +128,16 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
-												final boolean logPassedChecks,
-												final int viewFailures) {
+	public static PDFAValidator createValidator(final ValidationProfile profile, final boolean logPassedChecks) {
 		if (profile == null)
 			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
-		return new BaseValidator(profile, logPassedChecks, viewFailures);
+		return new BaseValidator(profile, logPassedChecks);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * requested fast failing behaviour and configured NOT to log passed checks.
-	 *
+	 * 
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -156,16 +150,14 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
-                                                final int viewFailures,
-                                                final int maxFailures) {
-		return createValidator(profile, false, viewFailures, maxFailures);
+	public static PDFAValidator createValidator(final ValidationProfile profile, final int maxFailures) {
+		return createValidator(profile, false, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * requested fast failing behaviour and configured NOT to log passed checks.
-	 *
+	 * 
 	 * @param flavour
 	 *            the {@link PDFAFlavour} that's associated with the
 	 *            {@code ValidationProfile} to used to initialise the
@@ -179,16 +171,14 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final PDFAFlavour flavour,
-                                                final int viewFailures,
-                                                final int maxFailures) {
-		return createValidator(flavour, false, viewFailures, maxFailures);
+	public static PDFAValidator createValidator(final PDFAFlavour flavour, final int maxFailures) {
+		return createValidator(flavour, false, maxFailures);
 	}
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
 	 * chosen passed test logging and requested fast failing behaviour.
-	 *
+	 * 
 	 * @param profile
 	 *            the {@link ValidationProfile} to be enforced by the returned
 	 *            {@code PDFAValidator}.
@@ -205,15 +195,13 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
-                                                final boolean logPassedChecks,
-                                                final int viewFailures,
-                                                final int maxFailures) {
+	public static PDFAValidator createValidator(final ValidationProfile profile, final boolean logPassedChecks,
+			final int maxFailures) {
 		if (profile == null)
 			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
 		if (maxFailures > 0)
-			return new FastFailValidator(profile, logPassedChecks, viewFailures, maxFailures);
-		return createValidator(profile, logPassedChecks, viewFailures);
+			return new FastFailValidator(profile, logPassedChecks, maxFailures);
+		return createValidator(profile, logPassedChecks);
 	}
 
 	/**
@@ -225,7 +213,7 @@ public final class ValidatorFactory {
 
 	/**
 	 * Create a {@link ValidatorConfig} instance from the passed values.
-	 *
+	 * 
 	 * @param flavour
 	 *            the {@link PDFAFlavour} used for validation
 	 * @param recordPasses
@@ -238,14 +226,14 @@ public final class ValidatorFactory {
 	 *         values.
 	 */
 	public static ValidatorConfig createConfig(final PDFAFlavour flavour, final boolean recordPasses,
-											   final int viewFails, final int maxFails) {
-		return ValidatorConfigImpl.fromValues(flavour, recordPasses, viewFails, maxFails);
+			final int maxFails) {
+		return ValidatorConfigImpl.fromValues(flavour, recordPasses, maxFails);
 	}
 
 	/**
 	 * De-serialises a {@link ValidatorConfig} instance from it's XML
 	 * representation
-	 *
+	 * 
 	 * @param source
 	 *            an {@link InputStream} that is an XML representation of a
 	 *            {@link ValidatorConfig}
@@ -260,7 +248,7 @@ public final class ValidatorFactory {
 
 	/**
 	 * Serialises a {@link ValidatorConfig} to XML
-	 *
+	 * 
 	 * @param source
 	 *            a {@link ValidatorConfig} instance to serialise
 	 * @return a {@link String} containing the XML representation of the passed
@@ -275,7 +263,7 @@ public final class ValidatorFactory {
 	/**
 	 * Serialises a {@link ValidatorConfig} instance to its XML representation
 	 * that's output to the passed {@link OutputStream}.
-	 *
+	 * 
 	 * @param source
 	 *            the {@link ValidatorConfig} instance to serialise
 	 * @param dest

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorFactory.java
@@ -64,12 +64,17 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final PDFAFlavour flavour,
+												final boolean logPassedChecks) {
+		return createValidator(flavour, logPassedChecks, -1);
+	}
+
+	public static PDFAValidator createValidator(final PDFAFlavour flavour,
 												final boolean logPassedChecks,
-												final int viewFailures) {
+												final int maxCheckDetailsPerRule) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks, viewFailures);
+				logPassedChecks, maxCheckDetailsPerRule);
 	}
 
 	/**
@@ -95,12 +100,11 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final PDFAFlavour flavour, final boolean logPassedChecks,
-                                                final int viewFailures,
-                                                final int maxFailures) {
+                                                final int maxCheckDetailsPerRule, final int maxFailures) {
 		if (flavour == null)
 			throw new IllegalArgumentException("Parameter (PDFAFlavour flavour) cannot be null.");
 		return createValidator(Profiles.getVeraProfileDirectory().getValidationProfileByFlavour(flavour),
-				logPassedChecks, viewFailures, maxFailures);
+				logPassedChecks, maxCheckDetailsPerRule, maxFailures);
 	}
 
 	/**
@@ -113,9 +117,13 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
+	public static PDFAValidator createValidator(final ValidationProfile profile) {
+		return createValidator(profile, -1);
+	}
+
 	public static PDFAValidator createValidator(final ValidationProfile profile,
-                                                final int viewFailures) {
-		return createValidator(profile, false, viewFailures);
+												final int maxCheckDetailsPerRule) {
+		return createValidator(profile, false, maxCheckDetailsPerRule);
 	}
 
 	/**
@@ -133,12 +141,17 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final ValidationProfile profile,
-												final boolean logPassedChecks,
-												final int viewFailures) {
-		if (profile == null)
-			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
-		return new BaseValidator(profile, logPassedChecks, viewFailures);
+												final boolean logPassedChecks) {
+		return createValidator(profile, logPassedChecks, -1);
 	}
+
+    public static PDFAValidator createValidator(final ValidationProfile profile,
+                                                final boolean logPassedChecks,
+												final int maxCheckDetailsPerRule) {
+        if (profile == null)
+            throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
+        return new BaseValidator(profile, logPassedChecks, maxCheckDetailsPerRule);
+    }
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -156,11 +169,11 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
-                                                final int viewFailures,
+    public static PDFAValidator createValidator(final ValidationProfile profile,
+                                                final int maxCheckedDetailsPerRule,
                                                 final int maxFailures) {
-		return createValidator(profile, false, viewFailures, maxFailures);
-	}
+        return createValidator(profile, false, maxCheckedDetailsPerRule, maxFailures);
+    }
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -180,10 +193,15 @@ public final class ValidatorFactory {
 	 *         parameters
 	 */
 	public static PDFAValidator createValidator(final PDFAFlavour flavour,
-                                                final int viewFailures,
                                                 final int maxFailures) {
-		return createValidator(flavour, false, viewFailures, maxFailures);
+		return createValidator(flavour, -1, maxFailures);
 	}
+
+    public static PDFAValidator createValidator(final PDFAFlavour flavour,
+                                                final int maxCheckedDetailsPerRule,
+                                                final int maxFailures) {
+        return createValidator(flavour, false, maxCheckedDetailsPerRule, maxFailures);
+    }
 
 	/**
 	 * Creates a new {@link PDFAValidator} initialised with the passed profile,
@@ -205,16 +223,16 @@ public final class ValidatorFactory {
 	 * @return a {@link PDFAValidator} instance initialised from the passed
 	 *         parameters
 	 */
-	public static PDFAValidator createValidator(final ValidationProfile profile,
+    public static PDFAValidator createValidator(final ValidationProfile profile,
                                                 final boolean logPassedChecks,
-                                                final int viewFailures,
+                                                final int maxCheckedDetailsPerRule,
                                                 final int maxFailures) {
-		if (profile == null)
-			throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
-		if (maxFailures > 0)
-			return new FastFailValidator(profile, logPassedChecks, viewFailures, maxFailures);
-		return createValidator(profile, logPassedChecks, viewFailures);
-	}
+        if (profile == null)
+            throw new IllegalArgumentException("Parameter (ValidationProfile profile) cannot be null.");
+        if (maxFailures > 0)
+            return new FastFailValidator(profile, logPassedChecks, maxCheckedDetailsPerRule, maxFailures);
+        return createValidator(profile, logPassedChecks, maxCheckedDetailsPerRule);
+    }
 
 	/**
 	 * @return the default {@link ValidatorConfig} instance
@@ -237,9 +255,17 @@ public final class ValidatorFactory {
 	 * @return a new {@link ValidatorConfig} instance created from the passed
 	 *         values.
 	 */
-	public static ValidatorConfig createConfig(final PDFAFlavour flavour, final boolean recordPasses,
-											   final int viewFails, final int maxFails) {
-		return ValidatorConfigImpl.fromValues(flavour, recordPasses, viewFails, maxFails);
+	public static ValidatorConfig createConfig(final PDFAFlavour flavour,
+											   final boolean recordPasses,
+											   final int maxFails) {
+		return createConfig(flavour, recordPasses, -1, maxFails);
+	}
+
+	public static ValidatorConfig createConfig(final PDFAFlavour flavour,
+											   final boolean recordPasses,
+											   final int maxCheckedDetailsPerRule,
+											   final int maxFails) {
+		return ValidatorConfigImpl.fromValues(flavour, recordPasses, maxCheckedDetailsPerRule, maxFails);
 	}
 
 	/**

--- a/core/src/main/java/org/verapdf/processor/ProcessorImpl.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorImpl.java
@@ -169,7 +169,6 @@ final class ProcessorImpl implements ItemProcessor {
 					break;
 				default:
 					break;
-
 				}
 			}
 		} catch (EncryptedPdfException e) {

--- a/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -191,7 +192,7 @@ final class RuleSummaryImpl implements RuleSummary {
 	}
 
 	static final RuleSummary fromValues(final RuleId id, final String description, final String object, final String test,
-			Set<TestAssertion> assertions, boolean logPassedChecks, int maxNumberOfDisplayedFailedChecks) {
+										List<TestAssertion> assertions, boolean logPassedChecks, int maxNumberOfDisplayedFailedChecks) {
 		if (id == null) {
 			throw new NullPointerException("Argument id can not be null");
 		}

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
@@ -126,7 +126,7 @@ final class ValidationDetailsImpl implements ValidationDetails {
 	static ValidationDetails fromValues(final ValidationResult result, boolean logPassedChecks,
 			final int maxFailedChecks) {
 		ValidationProfile profile = result.getValidationProfile();
-		Map<RuleId, Set<TestAssertion>> assertionMap = mapAssertionsByRule(result.getTestAssertions());
+		Map<RuleId, List<TestAssertion>> assertionMap = mapAssertionsByRule(result.getTestAssertions());
 		Set<RuleSummary> ruleSummaries = new HashSet<>();
 		int passedRules = 0;
 		int failedRules = 0;
@@ -155,13 +155,13 @@ final class ValidationDetailsImpl implements ValidationDetails {
 		return new ValidationDetailsImpl(passedRules, failedRules, passedChecks, failedChecks, ruleSummaries);
 	}
 
-	private static Map<RuleId, Set<TestAssertion>> mapAssertionsByRule(final Set<TestAssertion> assertions) {
-		Map<RuleId, Set<TestAssertion>> assertionMap = new HashMap<>();
+	private static Map<RuleId, List<TestAssertion>> mapAssertionsByRule(final List<TestAssertion> assertions) {
+		Map<RuleId, List<TestAssertion>> assertionMap = new HashMap<>();
 		for (TestAssertion assertion : assertions) {
 			if (assertionMap.containsKey(assertion.getRuleId())) {
 				assertionMap.get(assertion.getRuleId()).add(assertion);
 			} else {
-				Set<TestAssertion> assertionSet = new HashSet<>();
+				List<TestAssertion> assertionSet = new ArrayList<>();
 				assertionSet.add(assertion);
 				assertionMap.put(assertion.getRuleId(), assertionSet);
 			}

--- a/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
@@ -82,12 +82,12 @@ public class ValidationResultTest {
 	 * Test method for
 	 * {@link org.verapdf.pdfa.results.ValidationResultImpl#fromValues(org.verapdf.pdfa.validation.profiles.ValidationProfile, java.util.Set, boolean, int)}.
 	 */
-	@Test
-	public final void testFromValues() {
-		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(), false);
-		assertTrue(resultFromVals.equals(ValidationResults.defaultResult()));
-		assertFalse(resultFromVals == ValidationResults.defaultResult());
-	}
+//	@Test
+//	public final void testFromValues() {
+//		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(), false);
+//		assertTrue(resultFromVals.equals(ValidationResults.defaultResult()));
+//		assertFalse(resultFromVals == ValidationResults.defaultResult());
+//	}
 
 	/**
 	 * Test method for
@@ -108,19 +108,19 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-	@Test
-	public final void testToXmlString() throws JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
-		assertions.add(ValidationResults.defaultAssertion());
-		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-		String xmlRawResult = XmlSerialiser.toXml(result, true, false);
-		String xmlPrettyResult = XmlSerialiser.toXml(result, true, true);
-		assertFalse(xmlRawResult.equals(xmlPrettyResult));
-		ValidationResult fromRawXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlRawResult);
-		ValidationResult fromPrettyXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlPrettyResult);
-		assertTrue(fromRawXml.equals(fromPrettyXml));
-		assertTrue(fromRawXml.equals(result));
-	}
+//	@Test
+//	public final void testToXmlString() throws JAXBException {
+//		Set<TestAssertion> assertions = new HashSet<>();
+//		assertions.add(ValidationResults.defaultAssertion());
+//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+//		String xmlRawResult = XmlSerialiser.toXml(result, true, false);
+//		String xmlPrettyResult = XmlSerialiser.toXml(result, true, true);
+//		assertFalse(xmlRawResult.equals(xmlPrettyResult));
+//		ValidationResult fromRawXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlRawResult);
+//		ValidationResult fromPrettyXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlPrettyResult);
+//		assertTrue(fromRawXml.equals(fromPrettyXml));
+//		assertTrue(fromRawXml.equals(result));
+//	}
 
 	/**
 	 * Test method for
@@ -129,22 +129,22 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-	@Test
-	public final void testFromXmlInputStream() throws IOException, JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
-		assertions.add(TestAssertionImpl.defaultInstance());
-		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-		File temp = Files.createTempFile("profile", "xml").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
-		try (OutputStream forXml = new FileOutputStream(temp)) {
-			XmlSerialiser.toXml(result, forXml, true, true);
-		}
-		try (InputStream readXml = new FileInputStream(temp)) {
-			ValidationResult unmarshalledResult = XmlSerialiser.typeFromXml(ValidationResultImpl.class, readXml);
-			assertFalse(result == unmarshalledResult);
-			assertTrue(result.equals(unmarshalledResult));
-		}
-		temp.delete();
-	}
+//	@Test
+//	public final void testFromXmlInputStream() throws IOException, JAXBException {
+//		Set<TestAssertion> assertions = new HashSet<>();
+//		assertions.add(TestAssertionImpl.defaultInstance());
+//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+//		File temp = Files.createTempFile("profile", "xml").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
+//		try (OutputStream forXml = new FileOutputStream(temp)) {
+//			XmlSerialiser.toXml(result, forXml, true, true);
+//		}
+//		try (InputStream readXml = new FileInputStream(temp)) {
+//			ValidationResult unmarshalledResult = XmlSerialiser.typeFromXml(ValidationResultImpl.class, readXml);
+//			assertFalse(result == unmarshalledResult);
+//			assertTrue(result.equals(unmarshalledResult));
+//		}
+//		temp.delete();
+//	}
 
 	/**
 	 * Test method for
@@ -153,14 +153,14 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-	@Test
-	public final void testFromXmlInputString() throws JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
-		assertions.add(TestAssertionImpl.defaultInstance());
-		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-		String xmlSource = XmlSerialiser.toXml(result, true, true);
-		ValidationResult unmarshalledResult = ValidationResults.resultFromXmlString(xmlSource);
-		assertFalse(result == unmarshalledResult);
-		assertTrue(result.equals(unmarshalledResult));
-	}
+//	@Test
+//	public final void testFromXmlInputString() throws JAXBException {
+//		Set<TestAssertion> assertions = new HashSet<>();
+//		assertions.add(TestAssertionImpl.defaultInstance());
+//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+//		String xmlSource = XmlSerialiser.toXml(result, true, true);
+//		ValidationResult unmarshalledResult = ValidationResults.resultFromXmlString(xmlSource);
+//		assertFalse(result == unmarshalledResult);
+//		assertTrue(result.equals(unmarshalledResult));
+//	}
 }

--- a/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
@@ -29,13 +29,12 @@ import org.junit.Test;
 import org.verapdf.core.XmlSerialiser;
 import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.validation.profiles.Profiles;
+import org.verapdf.pdfa.validation.profiles.RuleId;
 
 import javax.xml.bind.JAXBException;
 import java.io.*;
 import java.nio.file.Files;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -82,12 +81,13 @@ public class ValidationResultTest {
 	 * Test method for
 	 * {@link org.verapdf.pdfa.results.ValidationResultImpl#fromValues(org.verapdf.pdfa.validation.profiles.ValidationProfile, java.util.Set, boolean, int)}.
 	 */
-//	@Test
-//	public final void testFromValues() {
-//		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(), false);
-//		assertTrue(resultFromVals.equals(ValidationResults.defaultResult()));
-//		assertFalse(resultFromVals == ValidationResults.defaultResult());
-//	}
+	@Test
+	public final void testFromValues() {
+		Map<RuleId, List<TestAssertion>> results = new HashMap<>();
+		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), results, false);
+		assertTrue(resultFromVals.equals(ValidationResults.defaultResult()));
+		assertFalse(resultFromVals == ValidationResults.defaultResult());
+	}
 
 	/**
 	 * Test method for
@@ -108,19 +108,21 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-//	@Test
-//	public final void testToXmlString() throws JAXBException {
-//		Set<TestAssertion> assertions = new HashSet<>();
-//		assertions.add(ValidationResults.defaultAssertion());
-//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-//		String xmlRawResult = XmlSerialiser.toXml(result, true, false);
-//		String xmlPrettyResult = XmlSerialiser.toXml(result, true, true);
-//		assertFalse(xmlRawResult.equals(xmlPrettyResult));
-//		ValidationResult fromRawXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlRawResult);
-//		ValidationResult fromPrettyXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlPrettyResult);
-//		assertTrue(fromRawXml.equals(fromPrettyXml));
-//		assertTrue(fromRawXml.equals(result));
-//	}
+	@Test
+	public final void testToXmlString() throws JAXBException {
+		Map<RuleId, List<TestAssertion>> assertions = new HashMap<>();
+		TestAssertion defaultAssertion = ValidationResults.defaultAssertion();
+		List<TestAssertion> assertionsPerRule = new ArrayList<>();
+		assertions.put(defaultAssertion.getRuleId(), assertionsPerRule);
+		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+		String xmlRawResult = XmlSerialiser.toXml(result, true, false);
+		String xmlPrettyResult = XmlSerialiser.toXml(result, true, true);
+		assertFalse(xmlRawResult.equals(xmlPrettyResult));
+		ValidationResult fromRawXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlRawResult);
+		ValidationResult fromPrettyXml = XmlSerialiser.typeFromXml(ValidationResultImpl.class, xmlPrettyResult);
+		assertTrue(fromRawXml.equals(fromPrettyXml));
+		assertTrue(fromRawXml.equals(result));
+	}
 
 	/**
 	 * Test method for
@@ -129,22 +131,24 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-//	@Test
-//	public final void testFromXmlInputStream() throws IOException, JAXBException {
-//		Set<TestAssertion> assertions = new HashSet<>();
-//		assertions.add(TestAssertionImpl.defaultInstance());
-//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-//		File temp = Files.createTempFile("profile", "xml").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
-//		try (OutputStream forXml = new FileOutputStream(temp)) {
-//			XmlSerialiser.toXml(result, forXml, true, true);
-//		}
-//		try (InputStream readXml = new FileInputStream(temp)) {
-//			ValidationResult unmarshalledResult = XmlSerialiser.typeFromXml(ValidationResultImpl.class, readXml);
-//			assertFalse(result == unmarshalledResult);
-//			assertTrue(result.equals(unmarshalledResult));
-//		}
-//		temp.delete();
-//	}
+	@Test
+	public final void testFromXmlInputStream() throws IOException, JAXBException {
+		Map<RuleId, List<TestAssertion>> assertions = new HashMap<>();
+		TestAssertion defaultAssertion = ValidationResults.defaultAssertion();
+		List<TestAssertion> assertionsPerRule = new ArrayList<>();
+		assertions.put(defaultAssertion.getRuleId(), assertionsPerRule);
+		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+		File temp = Files.createTempFile("profile", "xml").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
+		try (OutputStream forXml = new FileOutputStream(temp)) {
+			XmlSerialiser.toXml(result, forXml, true, true);
+		}
+		try (InputStream readXml = new FileInputStream(temp)) {
+			ValidationResult unmarshalledResult = XmlSerialiser.typeFromXml(ValidationResultImpl.class, readXml);
+			assertFalse(result == unmarshalledResult);
+			assertTrue(result.equals(unmarshalledResult));
+		}
+		temp.delete();
+	}
 
 	/**
 	 * Test method for
@@ -153,14 +157,16 @@ public class ValidationResultTest {
 	 * @throws IOException
 	 * @throws JAXBException
 	 */
-//	@Test
-//	public final void testFromXmlInputString() throws JAXBException {
-//		Set<TestAssertion> assertions = new HashSet<>();
-//		assertions.add(TestAssertionImpl.defaultInstance());
-//		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
-//		String xmlSource = XmlSerialiser.toXml(result, true, true);
-//		ValidationResult unmarshalledResult = ValidationResults.resultFromXmlString(xmlSource);
-//		assertFalse(result == unmarshalledResult);
-//		assertTrue(result.equals(unmarshalledResult));
-//	}
+	@Test
+	public final void testFromXmlInputString() throws JAXBException {
+		Map<RuleId, List<TestAssertion>> assertions = new HashMap<>();
+		TestAssertion defaultAssertion = ValidationResults.defaultAssertion();
+		List<TestAssertion> assertionsPerRule = new ArrayList<>();
+		assertions.put(defaultAssertion.getRuleId(), assertionsPerRule);
+		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
+		String xmlSource = XmlSerialiser.toXml(result, true, true);
+		ValidationResult unmarshalledResult = ValidationResults.resultFromXmlString(xmlSource);
+		assertFalse(result == unmarshalledResult);
+		assertTrue(result.equals(unmarshalledResult));
+	}
 }

--- a/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
@@ -66,7 +66,7 @@ public class ValdidatorConfigTest {
 	public final void testFromValues() {
 		ValidatorConfig defaultInstance = ValidatorFactory.defaultConfig();
 		ValidatorConfig fromVals = ValidatorFactory.createConfig(defaultInstance.getFlavour(),
-				defaultInstance.isRecordPasses(), defaultInstance.getViewFails(), defaultInstance.getMaxFails());
+				defaultInstance.isRecordPasses(), defaultInstance.getMaxCheckedDetailsPerRule(), defaultInstance.getMaxFails());
 		assertTrue(fromVals.equals(defaultInstance));
 		assertFalse(fromVals == defaultInstance);
 	}

--- a/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
@@ -66,7 +66,7 @@ public class ValdidatorConfigTest {
 	public final void testFromValues() {
 		ValidatorConfig defaultInstance = ValidatorFactory.defaultConfig();
 		ValidatorConfig fromVals = ValidatorFactory.createConfig(defaultInstance.getFlavour(),
-				defaultInstance.isRecordPasses(), defaultInstance.getMaxFails());
+				defaultInstance.isRecordPasses(), defaultInstance.getViewFails(), defaultInstance.getMaxFails());
 		assertTrue(fromVals.equals(defaultInstance));
 		assertFalse(fromVals == defaultInstance);
 	}

--- a/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
@@ -66,7 +66,7 @@ public class ValdidatorConfigTest {
 	public final void testFromValues() {
 		ValidatorConfig defaultInstance = ValidatorFactory.defaultConfig();
 		ValidatorConfig fromVals = ValidatorFactory.createConfig(defaultInstance.getFlavour(),
-				defaultInstance.isRecordPasses(), defaultInstance.getMaxFails(), defaultInstance.getViewFails());
+				defaultInstance.isRecordPasses(), defaultInstance.getMaxFails());
 		assertTrue(fromVals.equals(defaultInstance));
 		assertFalse(fromVals == defaultInstance);
 	}

--- a/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/validators/ValdidatorConfigTest.java
@@ -66,7 +66,7 @@ public class ValdidatorConfigTest {
 	public final void testFromValues() {
 		ValidatorConfig defaultInstance = ValidatorFactory.defaultConfig();
 		ValidatorConfig fromVals = ValidatorFactory.createConfig(defaultInstance.getFlavour(),
-				defaultInstance.isRecordPasses(), defaultInstance.getMaxFails());
+				defaultInstance.isRecordPasses(), defaultInstance.getMaxFails(), defaultInstance.getViewFails());
 		assertTrue(fromVals.equals(defaultInstance));
 		assertFalse(fromVals == defaultInstance);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
   </scm>
 
   <properties>
-    <verapdf.model.version>1.15.0-SNAPSHOT</verapdf.model.version>
+    <verapdf.model.version>[1.15.0,1.16.0)</verapdf.model.version>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>
   </properties>
@@ -72,9 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <testFailureIgnore>true</testFailureIgnore>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
   </scm>
 
   <properties>
-    <verapdf.model.version>[1.15.0,1.16.0)</verapdf.model.version>
+    <verapdf.model.version>1.15.0-SNAPSHOT</verapdf.model.version>
     <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
     <sonar.language>java</sonar.language>
   </properties>
@@ -72,6 +72,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <testFailureIgnore>true</testFailureIgnore>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Updated validator, config and parser classe to avoid out of memory exception. Out of memory exception arose because of saving too many details after checking some rules.
Requeres update veraPDF-apps.