### PR TITLE
Fixed issue: #905.

### DIFF
--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResult.java
@@ -28,7 +28,7 @@ import org.verapdf.pdfa.validation.profiles.ProfileDetails;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Created as the result of validating a PDF/A document against a
@@ -81,7 +81,7 @@ public interface ValidationResult {
     /**
      * @return the list of {@link TestAssertion}s made during PDF/A validation
      */
-    public Set<TestAssertion> getTestAssertions();
+    public List<TestAssertion> getTestAssertions();
 
     /**
      * @return validation profile which has been used for generating validation result

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -35,8 +35,8 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -52,27 +52,27 @@ final class ValidationResultImpl implements ValidationResult {
 	private final int totalAssertions;
 	@XmlElementWrapper
 	@XmlElement(name = "assertion")
-	private final Set<TestAssertion> assertions;
+	private final List<TestAssertion> assertions;
 	@XmlAttribute
 	private final boolean isCompliant;
 
 	private final ValidationProfile validationProfile;
 
 	private ValidationResultImpl() {
-		this(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(),
+		this(Profiles.defaultProfile(), Collections.<TestAssertion>emptyList(),
 				false);
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-			final Set<TestAssertion> assertions, final boolean isCompliant) {
+			final List<TestAssertion> assertions, final boolean isCompliant) {
 		this(validationProfile, assertions, isCompliant, assertions.size());
 	}
 
 	private ValidationResultImpl(final ValidationProfile validationProfile,
-			final Set<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
+			final List<TestAssertion> assertions, final boolean isCompliant, int totalAssertions) {
 		super();
 		this.flavour = validationProfile.getPDFAFlavour();
-		this.assertions = new HashSet<>(assertions);
+		this.assertions = new ArrayList<>(assertions);
 		this.isCompliant = isCompliant;
 		this.totalAssertions = totalAssertions;
 		this.profileDetails = validationProfile.getDetails();
@@ -115,8 +115,8 @@ final class ValidationResultImpl implements ValidationResult {
 	 * { @inheritDoc }
 	 */
 	@Override
-	public Set<TestAssertion> getTestAssertions() {
-		return Collections.unmodifiableSet(this.assertions);
+	public List<TestAssertion> getTestAssertions() {
+		return Collections.unmodifiableList(this.assertions);
 	}
 
 	/**
@@ -183,18 +183,18 @@ final class ValidationResultImpl implements ValidationResult {
 	}
 
 	static ValidationResultImpl fromValues(final ValidationProfile validationProfile,
-										   final Set<TestAssertion> assertions, final boolean isCompliant, final int totalChecks) {
+										   final List<TestAssertion> assertions, final boolean isCompliant, final int totalChecks) {
 		return new ValidationResultImpl(validationProfile, assertions, isCompliant, totalChecks);
 	}
 
 	static ValidationResultImpl fromValidationResult(ValidationResult toConvert) {
-		Set<TestAssertion> assertions = toConvert.getTestAssertions();
+		List<TestAssertion> assertions = toConvert.getTestAssertions();
 		return fromValues(toConvert.getValidationProfile(), assertions,
 				toConvert.isCompliant(), toConvert.getTotalAssertions());
 	}
 
 	static ValidationResultImpl stripPassedTests(ValidationResult toStrip) {
-		Set<TestAssertion> assertions = toStrip.getTestAssertions();
+		List<TestAssertion> assertions = toStrip.getTestAssertions();
 		return fromValues(toStrip.getValidationProfile(), stripPassedTests(assertions),
 				toStrip.isCompliant(), toStrip.getTotalAssertions());
 	}
@@ -211,12 +211,12 @@ final class ValidationResultImpl implements ValidationResult {
 		}
 	}
 
-	static Set<TestAssertion> stripPassedTests(final Set<TestAssertion> toStrip) {
-		Set<TestAssertion> strippedSet = new HashSet<>();
+	static List<TestAssertion> stripPassedTests(final List<TestAssertion> toStrip) {
+		List<TestAssertion> strippedList = new ArrayList<>();
 		for (TestAssertion test : toStrip) {
 			if (test.getStatus() != Status.PASSED)
-				strippedSet.add(test);
+				strippedList.add(test);
 		}
-		return strippedSet;
+		return strippedList;
 	}
 }

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResults.java
@@ -29,7 +29,7 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import org.verapdf.pdfa.validation.profiles.ValidationProfile;
 
 import javax.xml.bind.JAXBException;
-import java.util.Set;
+import java.util.List;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -54,7 +54,7 @@ public class ValidationResults {
 	 *            compliant with the indicated flavour
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final List<TestAssertion> assertions,
 													final boolean isCompliant) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -75,7 +75,7 @@ public class ValidationResults {
 	 * @param totalAssertions
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions,
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final List<TestAssertion> assertions,
 			final boolean isCompliant, final int totalAssertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
@@ -92,7 +92,7 @@ public class ValidationResults {
 	 *            the Set of TestAssertions reported by during validation
 	 * @return a new ValidationResult instance populated from the values
 	 */
-	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final Set<TestAssertion> assertions) {
+	public static ValidationResult resultFromValues(final ValidationProfile validationProfile, final List<TestAssertion> assertions) {
 		if (validationProfile == null)
 			throw new NullPointerException(VALIDATION_PROFILE_NOT_NULL_MESSAGE);
 		if (assertions == null)

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/BaseValidator.java
@@ -57,7 +57,7 @@ class BaseValidator implements PDFAValidator {
 	private final Deque<Object> objectsStack = new ArrayDeque<>();
 	private final Deque<String> objectsContext = new ArrayDeque<>();
 	private final Map<Rule, List<ObjectWithContext>> deferredRules = new HashMap<>();
-	protected final Set<TestAssertion> results = new HashSet<>();
+	protected final List<TestAssertion> results = new ArrayList<>();
 	protected int testCounter = 0;
 	protected boolean abortProcessing = false;
 	protected final boolean logPassedTests;
@@ -282,13 +282,22 @@ class BaseValidator implements PDFAValidator {
 										  final Rule rule) {
 		if (!this.abortProcessing) {
 			this.testCounter++;
-			Location location = ValidationResults.locationFromValues(this.rootType, locationContext);
-			TestAssertion assertion = ValidationResults.assertionFromValues(this.testCounter, rule.getRuleId(),
+            //TODO rebuild structure of project for secure saving assertions without overflow memory exception with big files.
+			Location location;
+            if (this.results.size() > 10_000) {
+				location = ValidationResults.locationFromValues(this.rootType, "");
+            } else {
+                location = ValidationResults.locationFromValues(this.rootType, locationContext);
+            }
+
+            TestAssertion assertion = ValidationResults.assertionFromValues(this.testCounter, rule.getRuleId(),
 					assertionResult ? Status.PASSED : Status.FAILED, rule.getDescription(), location);
-			if (this.isCompliant)
-				this.isCompliant = assertionResult;
-			if (!assertionResult || this.logPassedTests)
-				this.results.add(assertion);
+			if (this.isCompliant) {
+                this.isCompliant = assertionResult;
+            }
+			if (!assertionResult || this.logPassedTests) {
+					this.results.add(assertion);
+            }
 		}
 	}
 

--- a/core/src/main/java/org/verapdf/processor/reports/RuleSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/RuleSummary.java
@@ -23,6 +23,7 @@
  */
 package org.verapdf.processor.reports;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -49,5 +50,5 @@ public interface RuleSummary {
     public String getDescription();
     public String getObject();
     public String getTest();
-    public Set<Check> getChecks();
+    public List<Check> getChecks();
 }

--- a/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
@@ -32,9 +32,7 @@ import org.verapdf.pdfa.validation.profiles.RuleId;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -62,10 +60,10 @@ final class RuleSummaryImpl implements RuleSummary {
 	@XmlElement
 	private final String test;
 	@XmlElement(name = "check")
-	private final Set<Check> checks;
+	private final List<Check> checks;
 
 	private RuleSummaryImpl(final RuleId ruleId, final Status status, final int passedChecks, final int failedChecks,
-			final String description, final String object, final String test, final Set<Check> checks) {
+			final String description, final String object, final String test, final List<Check> checks) {
 		PDFAFlavour.Specification specification = ruleId.getSpecification();
 		this.specification = specification == null ? null : specification.getId();
 		this.clause = ruleId.getClause();
@@ -77,12 +75,12 @@ final class RuleSummaryImpl implements RuleSummary {
 		this.description = description;
 		this.object = object;
 		this.test = test;
-		this.checks = ((checks != null) && !checks.isEmpty()) ? new HashSet<>(checks) : null;
+		this.checks = ((checks != null) && !checks.isEmpty()) ? new ArrayList<>(checks) : null;
 	}
 
 	private RuleSummaryImpl(final RuleId ruleId, final Status status, final String description, final String object,
 			final String test) {
-		this(ruleId, status, 0, 0, description, object, test, Collections.<Check>emptySet());
+		this(ruleId, status, 0, 0, description, object, test, Collections.<Check>emptyList());
 	}
 
 	private RuleSummaryImpl() {
@@ -174,7 +172,7 @@ final class RuleSummaryImpl implements RuleSummary {
 	 * @return the checks
 	 */
 	@Override
-	public Set<Check> getChecks() {
+	public List<Check> getChecks() {
 		return this.checks;
 	}
 
@@ -191,7 +189,7 @@ final class RuleSummaryImpl implements RuleSummary {
 	}
 
 	static final RuleSummary fromValues(final RuleId id, final String description, final String object, final String test,
-			Set<TestAssertion> assertions, boolean logPassedChecks, int maxNumberOfDisplayedFailedChecks) {
+										List<TestAssertion> assertions, boolean logPassedChecks, int maxNumberOfDisplayedFailedChecks) {
 		if (id == null) {
 			throw new NullPointerException("Argument id can not be null");
 		}
@@ -201,7 +199,7 @@ final class RuleSummaryImpl implements RuleSummary {
 		if (assertions == null) {
 			throw new NullPointerException("Argument assertions can not be null");
 		}
-		Set<Check> checks = new HashSet<>();
+		List<Check> checks = new ArrayList<>();
 		Status status = Status.PASSED;
 		int passedChecks = 0;
 		int failedChecks = 0;

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
@@ -126,7 +126,7 @@ final class ValidationDetailsImpl implements ValidationDetails {
 	static ValidationDetails fromValues(final ValidationResult result, boolean logPassedChecks,
 			final int maxFailedChecks) {
 		ValidationProfile profile = result.getValidationProfile();
-		Map<RuleId, Set<TestAssertion>> assertionMap = mapAssertionsByRule(result.getTestAssertions());
+		Map<RuleId, List<TestAssertion>> assertionMap = mapAssertionsByRule(result.getTestAssertions());
 		Set<RuleSummary> ruleSummaries = new HashSet<>();
 		int passedRules = 0;
 		int failedRules = 0;
@@ -155,13 +155,13 @@ final class ValidationDetailsImpl implements ValidationDetails {
 		return new ValidationDetailsImpl(passedRules, failedRules, passedChecks, failedChecks, ruleSummaries);
 	}
 
-	private static Map<RuleId, Set<TestAssertion>> mapAssertionsByRule(final Set<TestAssertion> assertions) {
-		Map<RuleId, Set<TestAssertion>> assertionMap = new HashMap<>();
+	private static Map<RuleId, List<TestAssertion>> mapAssertionsByRule(final List<TestAssertion> assertions) {
+		Map<RuleId, List<TestAssertion>> assertionMap = new HashMap<>();
 		for (TestAssertion assertion : assertions) {
 			if (assertionMap.containsKey(assertion.getRuleId())) {
 				assertionMap.get(assertion.getRuleId()).add(assertion);
 			} else {
-				Set<TestAssertion> assertionSet = new HashSet<>();
+				List<TestAssertion> assertionSet = new ArrayList<>();
 				assertionSet.add(assertion);
 				assertionMap.put(assertion.getRuleId(), assertionSet);
 			}

--- a/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/ValidationResultTest.java
@@ -33,9 +33,7 @@ import org.verapdf.pdfa.validation.profiles.Profiles;
 import javax.xml.bind.JAXBException;
 import java.io.*;
 import java.nio.file.Files;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -46,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("static-method")
 public class ValidationResultTest {
 	private static final String DEFAULT_RESULT_STRING = "ValidationResult [flavour=" + PDFAFlavour.NO_FLAVOUR //$NON-NLS-1$
-			+ ", totalAssertions=" + 0 + ", assertions=" + Collections.<TestAssertion>emptySet() + ", isCompliant=" //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+			+ ", totalAssertions=" + 0 + ", assertions=" + Collections.<TestAssertion>emptyList() + ", isCompliant=" //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
 			+ false + "]"; //$NON-NLS-1$
 
 	/**
@@ -84,7 +82,7 @@ public class ValidationResultTest {
 	 */
 	@Test
 	public final void testFromValues() {
-		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), Collections.<TestAssertion>emptySet(), false);
+		ValidationResult resultFromVals = ValidationResults.resultFromValues(Profiles.defaultProfile(), Collections.<TestAssertion>emptyList(), false);
 		assertTrue(resultFromVals.equals(ValidationResults.defaultResult()));
 		assertFalse(resultFromVals == ValidationResults.defaultResult());
 	}
@@ -110,7 +108,7 @@ public class ValidationResultTest {
 	 */
 	@Test
 	public final void testToXmlString() throws JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
+		List<TestAssertion> assertions = new ArrayList<>();
 		assertions.add(ValidationResults.defaultAssertion());
 		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
 		String xmlRawResult = XmlSerialiser.toXml(result, true, false);
@@ -131,7 +129,7 @@ public class ValidationResultTest {
 	 */
 	@Test
 	public final void testFromXmlInputStream() throws IOException, JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
+		List<TestAssertion> assertions = new ArrayList<>();
 		assertions.add(TestAssertionImpl.defaultInstance());
 		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
 		File temp = Files.createTempFile("profile", "xml").toFile(); //$NON-NLS-1$ //$NON-NLS-2$
@@ -155,7 +153,7 @@ public class ValidationResultTest {
 	 */
 	@Test
 	public final void testFromXmlInputString() throws JAXBException {
-		Set<TestAssertion> assertions = new HashSet<>();
+		List<TestAssertion> assertions = new ArrayList<>();
 		assertions.add(TestAssertionImpl.defaultInstance());
 		ValidationResult result = ValidationResults.resultFromValues(Profiles.defaultProfile(), assertions);
 		String xmlSource = XmlSerialiser.toXml(result, true, true);


### PR DESCRIPTION
Updated BaseValidator method processAssertionResult to avoid out of memory exception. Out of memory exception arose because of saving too many details after checking some rules.
Integration tests passed.
Closes  https://github.com/veraPDF/veraPDF-library/issues/905.