### PR TITLE
Incorrect output encoding

### DIFF
--- a/core/src/main/java/org/verapdf/core/XmlSerialiser.java
+++ b/core/src/main/java/org/verapdf/core/XmlSerialiser.java
@@ -399,7 +399,7 @@ public final class XmlSerialiser {
 	private static Marshaller marshaller(JAXBContext ctx, boolean format, boolean fragment) throws JAXBException {
 		Marshaller m = ctx.createMarshaller();
 		m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.valueOf(format));
-        m.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
+		m.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
 		if (fragment) {
 			m.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 		}

--- a/core/src/main/java/org/verapdf/core/XmlSerialiser.java
+++ b/core/src/main/java/org/verapdf/core/XmlSerialiser.java
@@ -29,6 +29,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -398,6 +399,7 @@ public final class XmlSerialiser {
 	private static Marshaller marshaller(JAXBContext ctx, boolean format, boolean fragment) throws JAXBException {
 		Marshaller m = ctx.createMarshaller();
 		m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.valueOf(format));
+        m.setProperty(Marshaller.JAXB_ENCODING, StandardCharsets.UTF_8.name());
 		if (fragment) {
 			m.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 		}


### PR DESCRIPTION
We found an issue using veraPDF application in serverMode (on Windows) and validating files containing non Ascii characters in file names. Problems is in the final XML report when name of input file is not encoded in UTF-8 but is in local encoding. Marshaller is by default using local specific encoding and not UTF-8. 