### PR TITLE
Performance optimization for multi-threaded execution

### DIFF
--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/JavaScriptEvaluator.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/JavaScriptEvaluator.java
@@ -18,36 +18,37 @@ import java.util.Map;
 public class JavaScriptEvaluator {
 	private static final int OPTIMIZATION_LEVEL = 9;
 
-	private static Context context;
+	private static final ThreadLocal<Context> context = new ThreadLocal<>();
 
-	private static final Map<String, Script> ruleScripts = new HashMap<>();
-	private static final Map<String, Script> variableScripts = new HashMap<>();
-	private static final Map<String, Script> argumentScripts = new HashMap<>();
+	private static final ThreadLocal<Map<String, Script>> ruleScripts = ThreadLocal.withInitial(HashMap::new);
+	private static final ThreadLocal<Map<String, Script>> variableScripts = ThreadLocal.withInitial(HashMap::new);
+	private static final ThreadLocal<Map<String, Script>> argumentScripts = ThreadLocal.withInitial(HashMap::new);
 
-	public static synchronized ScriptableObject initialise() {
-		context = Context.enter();
-		context.setOptimizationLevel(OPTIMIZATION_LEVEL);
-		return context.initStandardObjects();
+	public static ScriptableObject initialise() {
+		final Context newContext = Context.enter();
+		context.set(newContext);
+		newContext.setOptimizationLevel(OPTIMIZATION_LEVEL);
+		return newContext.initStandardObjects();
 	}
 
-	public static synchronized java.lang.Object evaluateString(String source, ScriptableObject scope) {
-		return context.evaluateString(scope, source, null, 0, null);
+	public static java.lang.Object evaluateString(String source, ScriptableObject scope) {
+		return context.get().evaluateString(scope, source, null, 0, null);
 	}
 
-	public static synchronized java.lang.Object evalVariableResult(Variable variable, Object object, ScriptableObject scope) {
+	public static java.lang.Object evalVariableResult(Variable variable, Object object, ScriptableObject scope) {
 		Script script;
-		if (!variableScripts.containsKey(variable.getName())) {
+		if (!variableScripts.get().containsKey(variable.getName())) {
 			String source = getStringScript(object, variable.getValue());
 			script = JavaScriptEvaluator.compileString(source);
 
-			variableScripts.put(variable.getName(), script);
+			variableScripts.get().put(variable.getName(), script);
 		} else {
-			script = variableScripts.get(variable.getName());
+			script = variableScripts.get().get(variable.getName());
 		}
 
 		scope.put("obj", scope, object);
 
-		java.lang.Object res = script.exec(context, scope);
+		java.lang.Object res = script.exec(context.get(), scope);
 
 		if (res instanceof NativeJavaObject) {
 			res = ((NativeJavaObject) res).unwrap();
@@ -56,7 +57,7 @@ public class JavaScriptEvaluator {
 	}
 
 	private static Script compileString(String source) {
-		return context.compileString(source, null, 0, null);
+		return context.get().compileString(source, null, 0, null);
 	}
 
 	private static String getStringScript(Object obj, String arg) {
@@ -107,33 +108,33 @@ public class JavaScriptEvaluator {
 		return getStringScript(obj, "(" + test + ")==true");
 	}
 
-	public static synchronized boolean getTestEvalResult(Object obj, Rule rule, ScriptableObject scope) {
+	public static boolean getTestEvalResult(Object obj, Rule rule, ScriptableObject scope) {
 		scope.put("obj", scope, obj);
 
 		Script scr;
 		String test = rule.getTest();
-		if (!ruleScripts.containsKey(test)) {
+		if (!ruleScripts.get().containsKey(test)) {
 			scr = compileString(getScript(obj, test));
-			ruleScripts.put(test, scr);
+			ruleScripts.get().put(test, scr);
 		} else {
-			scr = ruleScripts.get(test);
+			scr = ruleScripts.get().get(test);
 		}
 
-		boolean testEvalResult = (Boolean) scr.exec(context, scope);
+		boolean testEvalResult = (Boolean) scr.exec(context.get(), scope);
 
 		return testEvalResult;
 	}
 
-	private static synchronized String getErrorArgumentResult(String argument, Object obj, ScriptableObject scope) {
+	private static String getErrorArgumentResult(String argument, Object obj, ScriptableObject scope) {
 		Script scr;
 
-		if (!argumentScripts.containsKey(argument)) {
+		if (!argumentScripts.get().containsKey(argument)) {
 			scr = JavaScriptEvaluator.compileString(getStringScript(obj, argument));
-			argumentScripts.put(argument, scr);
+			argumentScripts.get().put(argument, scr);
 		} else {
-			scr = argumentScripts.get(argument);
+			scr = argumentScripts.get().get(argument);
 		}
-		java.lang.Object res = scr.exec(context, scope);
+		java.lang.Object res = scr.exec(context.get(), scope);
 		if (res instanceof NativeJavaObject) {
 			res = ((NativeJavaObject) res).unwrap();
 		}
@@ -150,7 +151,7 @@ public class JavaScriptEvaluator {
 
 	}
 
-	public static synchronized List<ErrorArgument> getErrorArgumentsResult(Object obj, List<ErrorArgument> arguments,
+	public static List<ErrorArgument> getErrorArgumentsResult(Object obj, List<ErrorArgument> arguments,
 																		   ScriptableObject scope) {
 		List<ErrorArgument> result = new LinkedList<>();
 		for (ErrorArgument argument : arguments) {


### PR DESCRIPTION
JavaScriptEvaluator.getTestEvalResult blocks threads while concurrent validation 
Thus I created issue #1408
This is the pull request to fix the issue.