### PR TITLE
Update app name for html report

### DIFF
--- a/core/src/main/java/org/verapdf/report/HTMLReport.java
+++ b/core/src/main/java/org/verapdf/report/HTMLReport.java
@@ -39,7 +39,7 @@ public final class HTMLReport {
 	private static final String xslExt = ".xsl"; //$NON-NLS-1$
 	private static final String detailedReport = resourceRoot + "DetailedHtmlReport" + xslExt; //$NON-NLS-1$
 	private static final String summaryReport = resourceRoot + "SummaryHtmlReport" + xslExt; //$NON-NLS-1$
-	private static final String GUI = "gui"; //$NON-NLS-1$
+	private static final String APPS = "apps"; //$NON-NLS-1$
 	private static final String VERAPDF_REST = "verapdf-rest"; //$NON-NLS-1$
 
 	private HTMLReport() {
@@ -102,7 +102,7 @@ public final class HTMLReport {
 				return VERAPDF_REST;
 			}
 		}
-		return GUI;
+		return APPS;
 	}
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how the application label appears in generated reports: when REST details are present the REST identifier is used; otherwise the label now shows "apps" instead of "gui", ensuring consistent and accurate report labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->