### PR TITLE
Add an automatic module name to the MANIFEST

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,5 +118,18 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jar-plugin</artifactId>
+              <configuration>
+                  <archive>
+                      <manifestEntries>
+                          <Automatic-Module-Name>org.verapdf.core</Automatic-Module-Name>
+                      </manifestEntries>
+                  </archive>
+              </configuration>
+          </plugin>
+      </plugins>
   </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,6 +122,7 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jar-plugin</artifactId>
+              <version>3.4.2</version>
               <configuration>
                   <archive>
                       <manifestEntries>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,7 +122,6 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jar-plugin</artifactId>
-              <version>3.4.2</version>
               <configuration>
                   <archive>
                       <manifestEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-parent</artifactId>
-    <version>1.29.1</version>
+    <version>1.29.6</version>
   </parent>
 
   <groupId>org.verapdf</groupId>
@@ -78,15 +78,6 @@
   </properties>
 
   <build>
-      <pluginManagement>
-          <plugins>
-              <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
-                  <artifactId>maven-jar-plugin</artifactId>
-                  <version>3.4.2</version>
-              </plugin>
-          </plugins>
-      </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,15 @@
   </properties>
 
   <build>
+      <pluginManagement>
+          <plugins>
+              <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-jar-plugin</artifactId>
+                  <version>3.4.2</version>
+              </plugin>
+          </plugins>
+      </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/xmp-core/pom.xml
+++ b/xmp-core/pom.xml
@@ -27,7 +27,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/xmp-core/pom.xml
+++ b/xmp-core/pom.xml
@@ -22,4 +22,20 @@
     </license>
   </licenses>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.verapdf.xmp.core</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/xmp-core/pom.xml
+++ b/xmp-core/pom.xml
@@ -27,6 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Automatic-Module-Name entries to JAR manifests for core and XMP-core to improve module identification.
  * Bumped parent project version from 1.29.1 to 1.29.6.
  * Packaging/manifest-only changes; no runtime behavior or dependencies were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->