### PR TITLE
Fix exception when getdeclarations() returned null

### DIFF
--- a/core/src/main/java/org/verapdf/model/impl/axl/AXLMainXMPPackage.java
+++ b/core/src/main/java/org/verapdf/model/impl/axl/AXLMainXMPPackage.java
@@ -26,7 +26,10 @@ import org.verapdf.xmp.impl.VeraPDFXMPNode;
 import org.verapdf.model.baselayer.Object;
 import org.verapdf.model.xmplayer.MainXMPPackage;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Current class is representation of XMPPackage interface from abstract model based on adobe xmp library
@@ -123,6 +126,6 @@ public class AXLMainXMPPackage extends AXLXMPPackage implements MainXMPPackage {
         if (xmpMetadata != null) {
             return xmpMetadata.getDeclarations();
         }
-        return new HashSet<>();
+        return Collections.emptySet();
     }
 }

--- a/core/src/main/java/org/verapdf/model/impl/axl/AXLMainXMPPackage.java
+++ b/core/src/main/java/org/verapdf/model/impl/axl/AXLMainXMPPackage.java
@@ -26,10 +26,7 @@ import org.verapdf.xmp.impl.VeraPDFXMPNode;
 import org.verapdf.model.baselayer.Object;
 import org.verapdf.model.xmplayer.MainXMPPackage;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Current class is representation of XMPPackage interface from abstract model based on adobe xmp library
@@ -126,6 +123,6 @@ public class AXLMainXMPPackage extends AXLXMPPackage implements MainXMPPackage {
         if (xmpMetadata != null) {
             return xmpMetadata.getDeclarations();
         }
-        return null;
+        return new HashSet<>();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved XMP metadata handling to return empty collections instead of null values when declarations are missing. This reduces null-related errors, simplifies downstream code by guaranteeing a collection is returned, and enhances overall stability and consistency when processing absent XMP declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->