### PR TITLE
Avoid NPE in XMP schema registry on threads that did not seed the containers

### DIFF
--- a/core/src/test/java/org/verapdf/model/impl/axl/XMPSchemaRegistryThreadTest.java
+++ b/core/src/test/java/org/verapdf/model/impl/axl/XMPSchemaRegistryThreadTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of veraPDF Library core, a module of the veraPDF project.
+ * Copyright (c) 2015-2026, veraPDF Consortium <info@verapdf.org>
+ * All rights reserved.
+ *
+ * veraPDF Library core is free software: you can redistribute it and/or modify
+ * it under the terms of either:
+ *
+ * The GNU General public license GPLv3+.
+ * You should have received a copy of the GNU General Public License
+ * along with veraPDF Library core as the LICENSE.GPL file in the root of the source
+ * tree.  If not, see http://www.gnu.org/licenses/ or
+ * https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * The Mozilla Public License MPLv2+.
+ * You should have received a copy of the Mozilla Public License along with
+ * veraPDF Library core as the LICENSE.MPL file in the root of the source tree.
+ * If a copy of the MPL was not distributed with this file, you can obtain one at
+ * http://mozilla.org/MPL/2.0/.
+ */
+package org.verapdf.model.impl.axl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.verapdf.xmp.XMPConst;
+import org.verapdf.xmp.XMPMetaFactory;
+
+public class XMPSchemaRegistryThreadTest {
+
+    @Test
+    public void getNamespacePrefixFromForeignThread() throws InterruptedException {
+        // The singleton registry is constructed on this thread, which seeds the
+        // per-thread containers only here. Another thread (such as a virtual
+        // thread) has its own empty container slots.
+        XMPMetaFactory.getSchemaRegistry();
+
+        AtomicReference<String> prefix = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                prefix.set(XMPMetaFactory.getSchemaRegistry().getNamespacePrefix(XMPConst.NS_RDF));
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        worker.start();
+        worker.join();
+
+        assertEquals(null, failure.get());
+        assertEquals("rdf:", prefix.get());
+    }
+}

--- a/xmp-core/src/main/java/org/verapdf/xmp/containers/StaticXmpCoreContainers.java
+++ b/xmp-core/src/main/java/org/verapdf/xmp/containers/StaticXmpCoreContainers.java
@@ -8,12 +8,12 @@ public class StaticXmpCoreContainers {
     /**
      * a map from a namespace URI to its registered prefix
      */
-    private static final ThreadLocal<Map<String, String>> namespaceToPrefixMap = new ThreadLocal<>();
+    private static final ThreadLocal<Map<String, String>> namespaceToPrefixMap = ThreadLocal.withInitial(HashMap::new);
 
     /**
      * a map from a prefix to the associated namespace URI
      */
-    private static final ThreadLocal<Map<String, String>> prefixToNamespaceMap = new ThreadLocal<>();
+    private static final ThreadLocal<Map<String, String>> prefixToNamespaceMap = ThreadLocal.withInitial(HashMap::new);
 
     /**
      * Clears all namespaces and prefixes.


### PR DESCRIPTION
The thread-local namespace and prefix maps in StaticXmpCoreContainers are only populated by clearAllContainers(), which the XMPSchemaRegistryImpl constructor calls on the constructing thread. Any other thread, such as a virtual thread spawned after the singleton registry is built, sees a null map and getNamespacePrefix() throws a NullPointerException before it can fall back to the standard namespace map. Initialising the thread-locals with ThreadLocal.withInitial(HashMap::new) gives every thread an empty map, so lookups fall through to the standard maps as intended. Fixes #1603.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added thread-safety verification tests for XMP schema registry operations.

* **Refactor**
  * Improved initialization of thread-local storage to ensure proper multi-threaded operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->