### PR TITLE
Make JAXB final fields non-final for reflection compatibility

### DIFF
--- a/core/src/main/java/org/verapdf/ReleaseDetails.java
+++ b/core/src/main/java/org/verapdf/ReleaseDetails.java
@@ -57,11 +57,11 @@ public final class ReleaseDetails {
 	private static final Map<String, ReleaseDetails> DETAILS = initDetailsMap();
 
 	@XmlAttribute
-	private final String id;
+	private String id;
 	@XmlAttribute
-	private final String version;
+	private String version;
 	@XmlAttribute
-	private final Date buildDate;
+	private Date buildDate;
 
 	private ReleaseDetails() {
 		this("name", "version", new Date()); //$NON-NLS-1$ //$NON-NLS-2$

--- a/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
+++ b/core/src/main/java/org/verapdf/component/AuditDurationImpl.java
@@ -43,9 +43,9 @@ public final class AuditDurationImpl implements AuditDuration {
 	private static final int minInHour = 60;
 
 	@XmlAttribute
-	private final long start;
+	private long start;
 	@XmlAttribute
-	private final long finish;
+	private long finish;
 
 	private AuditDurationImpl() {
 		this(0, 0);

--- a/core/src/main/java/org/verapdf/component/ComponentDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/component/ComponentDetailsImpl.java
@@ -40,15 +40,15 @@ class ComponentDetailsImpl implements ComponentDetails {
 	private static final URI defaultId = URI.create("http://component.verapdf.org#default");
 	private static final ComponentDetailsImpl defaultInstance = new ComponentDetailsImpl();
 	@XmlAttribute
-	private final URI id;
+	private URI id;
 	@XmlAttribute
-	private final String name;
+	private String name;
 	@XmlAttribute
-	private final String version;
+	private String version;
 	@XmlElement
-	private final String provider;
+	private String provider;
 	@XmlElement
-	private final String description;
+	private String description;
 
 	private ComponentDetailsImpl() {
 		this(defaultId, "name", "version", "provider", "description");

--- a/core/src/main/java/org/verapdf/component/LogImpl.java
+++ b/core/src/main/java/org/verapdf/component/LogImpl.java
@@ -26,11 +26,11 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 final class LogImpl implements Log {
     @XmlAttribute
-    private final int occurrences;
+    private int occurrences;
     @XmlAttribute
-    private final String level;
+    private String level;
     @XmlValue
-    private final String message;
+    private String message;
 
     private LogImpl(final int occurrences, String level, final String message) {
         this.occurrences = occurrences;

--- a/core/src/main/java/org/verapdf/component/LogsSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/component/LogsSummaryImpl.java
@@ -40,9 +40,9 @@ public final class LogsSummaryImpl implements LogsSummary {
     private static final Logger logger = Logger.getLogger(LogsSummaryImpl.class.getCanonicalName());
     private static final String logBeginning = "[log]";
     @XmlAttribute
-    private final int logsCount;
+    private int logsCount;
     @XmlElement(name = "logMessage")
-    private final Set<Log> logs;
+    private Set<Log> logs;
 
     private LogsSummaryImpl() {
         this(0, Collections.emptySet());

--- a/core/src/main/java/org/verapdf/features/FeatureExtractorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/features/FeatureExtractorConfigImpl.java
@@ -36,7 +36,7 @@ final class FeatureExtractorConfigImpl implements FeatureExtractorConfig {
 	private static final FeatureExtractorConfig DEFAULT = new FeatureExtractorConfigImpl(EnumSet.of(FeatureObjectType.INFORMATION_DICTIONARY));
 	@XmlElementWrapper(name="enabledFeatures")
 	@XmlElement(name="feature")
-	private final EnumSet<FeatureObjectType> enabledFeatures;
+	private EnumSet<FeatureObjectType> enabledFeatures;
 
 	private FeatureExtractorConfigImpl() {
 		this(EnumSet.noneOf(FeatureObjectType.class));

--- a/core/src/main/java/org/verapdf/metadata/fixer/FixerConfigImpl.java
+++ b/core/src/main/java/org/verapdf/metadata/fixer/FixerConfigImpl.java
@@ -33,7 +33,7 @@ final class FixerConfigImpl implements MetadataFixerConfig {
 	public static final String DEFAULT_PREFIX = "veraFixMd_";  //$NON-NLS-1$
 	private static final MetadataFixerConfig defaultInstance = new FixerConfigImpl();
 	@XmlAttribute
-	private final String fixesPrefix;
+	private String fixesPrefix;
 
 	private FixerConfigImpl() {
 		this(DEFAULT_PREFIX); //$NON-NLS-1$

--- a/core/src/main/java/org/verapdf/pdfa/results/LocationImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/LocationImpl.java
@@ -42,9 +42,9 @@ final class LocationImpl implements Location {
     private static final String DEREF_REPL = "\\(";
     private static final Pattern DEREF_PATTERN = Pattern.compile(DEREF_REGEX);
     @XmlElement
-    private final String level;
+    private String level;
     @XmlElement
-    private final String context;
+    private String context;
 
     private LocationImpl() {
         this("level", "context");

--- a/core/src/main/java/org/verapdf/pdfa/results/MetadataFixerResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/MetadataFixerResultImpl.java
@@ -34,10 +34,10 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 @XmlRootElement(name = "fixerResult")
 public final class MetadataFixerResultImpl implements MetadataFixerResult {
 	@XmlAttribute
-	private final RepairStatus status;
+	private RepairStatus status;
 	@XmlElementWrapper
 	@XmlElement(name = "fix")
-	private final List<String> appliedFixes;
+	private List<String> appliedFixes;
 
 	private MetadataFixerResultImpl() {
 		this(RepairStatus.NO_ACTION, new ArrayList<>());

--- a/core/src/main/java/org/verapdf/pdfa/results/TestAssertionImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/TestAssertionImpl.java
@@ -43,19 +43,19 @@ import java.util.Objects;
 final class TestAssertionImpl implements TestAssertion {
     private static final TestAssertionImpl DEFAULT = new TestAssertionImpl();
     @XmlAttribute
-    private final int ordinal;
+    private int ordinal;
     @XmlElement
-    private final RuleId ruleId;
+    private RuleId ruleId;
     @XmlAttribute
-    private final Status status;
+    private Status status;
     @XmlElement
-    private final String message;
+    private String message;
     @XmlElement
-    private final Location location;
+    private Location location;
     @XmlElement
-    private final String locationContext;
+    private String locationContext;
     @XmlElement
-    private final String errorMessage;
+    private String errorMessage;
 
     private final List<ErrorArgument> errorArguments;
 

--- a/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/results/ValidationResultImpl.java
@@ -45,18 +45,18 @@ import java.util.*;
 final class ValidationResultImpl implements ValidationResult {
 	private static final ValidationResultImpl DEFAULT = new ValidationResultImpl();
 	@XmlAttribute
-	private final PDFAFlavour flavour;
+	private PDFAFlavour flavour;
 	@XmlElement
-	private final ProfileDetails profileDetails;
+	private ProfileDetails profileDetails;
 	@XmlAttribute
-	private final int totalAssertions;
+	private int totalAssertions;
 	@XmlElementWrapper
 	@XmlElement(name = "assertion")
-	private final List<TestAssertion> assertions;
+	private List<TestAssertion> assertions;
 	@XmlAttribute
-	private final boolean isCompliant;
+	private boolean isCompliant;
 	@XmlAttribute
-	private final JobEndStatus jobEndStatus;
+	private JobEndStatus jobEndStatus;
 
 	private HashMap<RuleId, Integer> failedChecks = null;
 

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/ErrorArgumentImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/ErrorArgumentImpl.java
@@ -33,9 +33,9 @@ import java.util.Objects;
 public final class ErrorArgumentImpl implements ErrorArgument {
     private static final ErrorArgumentImpl DEFAULT = new ErrorArgumentImpl();
     @XmlValue
-    private final String argument;
+    private String argument;
     @XmlAttribute(name = "name")
-    private final String name;
+    private String name;
     private final String argumentValue;
 
     private ErrorArgumentImpl() {

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/ErrorDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/ErrorDetailsImpl.java
@@ -38,10 +38,10 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 final class ErrorDetailsImpl implements ErrorDetails {
     private static final ErrorDetailsImpl DEFAULT = new ErrorDetailsImpl();
     @XmlElement
-    private final String message;
+    private String message;
     @XmlElementWrapper
     @XmlElement(name = "argument")
-    private final List<ErrorArgument> arguments;
+    private List<ErrorArgument> arguments;
 
     private ErrorDetailsImpl() {
         this("message", Collections.emptyList());

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/ProfileDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/ProfileDetailsImpl.java
@@ -37,13 +37,13 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 final class ProfileDetailsImpl implements ProfileDetails {
     private static final ProfileDetailsImpl DEFAULT = new ProfileDetailsImpl();
     @XmlElement
-    private final String name;
+    private String name;
     @XmlElement
-    private final String description;
+    private String description;
     @XmlAttribute
-    private final String creator;
+    private String creator;
     @XmlAttribute
-    private final Date created;
+    private Date created;
 
     private ProfileDetailsImpl() {
         this("name", "description", "creator", new Date(0L));

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/ReferenceImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/ReferenceImpl.java
@@ -41,9 +41,9 @@ import java.util.Objects;
 final class ReferenceImpl implements Reference {
     private static final ReferenceImpl DEFAULT = new ReferenceImpl();
     @XmlAttribute
-    private final String specification;
+    private String specification;
     @XmlAttribute
-    private final String clause;
+    private String clause;
     
     private ReferenceImpl() {
         this("specification", "clause");

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/RuleIdImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/RuleIdImpl.java
@@ -37,11 +37,11 @@ import org.verapdf.pdfa.flavours.PDFAFlavour.Specification;
 final class RuleIdImpl implements RuleId {
     private static final RuleIdImpl DEFAULT = new RuleIdImpl();
     @XmlAttribute
-    private final Specification specification;
+    private Specification specification;
     @XmlAttribute
-    private final String clause;
+    private String clause;
     @XmlAttribute
-    private final int testNumber;
+    private int testNumber;
 
     private RuleIdImpl() {
         this(Specification.NO_STANDARD, "clause", 0);

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/RuleImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/RuleImpl.java
@@ -43,22 +43,22 @@ import java.util.*;
 final class RuleImpl implements Rule {
     private static final RuleImpl DEFAULT = new RuleImpl();
     @XmlElement
-    private final RuleId id;
+    private RuleId id;
     @XmlAttribute
-    private final String object;
+    private String object;
     @XmlAttribute
-    private final Boolean deferred;
+    private Boolean deferred;
     @XmlAttribute
-    private final String tags;
+    private String tags;
     @XmlElement
-    private final String description;
+    private String description;
     @XmlElement
-    private final String test;
+    private String test;
     @XmlElement
-    private final ErrorDetails error;
+    private ErrorDetails error;
     @XmlElementWrapper
     @XmlElement(name = "reference")
-    private final List<Reference> references = new ArrayList<>();
+    private List<Reference> references = new ArrayList<>();
 
     private RuleImpl() {
         this(RuleIdImpl.defaultInstance(), "object", null, null, "description", "test",

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/ValidationProfileImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/ValidationProfileImpl.java
@@ -46,17 +46,17 @@ final class ValidationProfileImpl implements ValidationProfile {
     private final Object objectRuleMapAndRuleLookupLock = new Object();
 
     @XmlAttribute
-    private final PDFAFlavour flavour;
+    private PDFAFlavour flavour;
     @XmlElement
-    private final ProfileDetails details;
+    private ProfileDetails details;
     @XmlElement
-    private final String hash;
+    private String hash;
     @XmlElementWrapper
     @XmlElement(name = "rule")
-    private final Set<Rule> rules;
+    private Set<Rule> rules;
     @XmlElementWrapper
     @XmlElement(name = "variable")
-    private final Set<Variable> variables;
+    private Set<Variable> variables;
 
     private ValidationProfileImpl() {
         this(PDFAFlavour.NO_FLAVOUR, ProfileDetailsImpl.defaultInstance(),

--- a/core/src/main/java/org/verapdf/pdfa/validation/profiles/VariableImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/profiles/VariableImpl.java
@@ -42,13 +42,13 @@ import java.util.Objects;
 final class VariableImpl implements Variable {
     private static final VariableImpl DEFAULT = new VariableImpl();
     @XmlAttribute
-    private final String name;
+    private String name;
     @XmlAttribute
-    private final String object;
+    private String object;
     @XmlElement
-    private final String defaultValue;
+    private String defaultValue;
     @XmlElement
-    private final String value;
+    private String value;
 
     private VariableImpl() {
         this("name", "object", "defaultValue", "value");

--- a/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/pdfa/validation/validators/ValidatorConfigImpl.java
@@ -44,21 +44,21 @@ final class ValidatorConfigImpl implements ValidatorConfig {
 	private PDFAFlavour flavour;
 	private PDFAFlavour defaultFlavour;
 	@XmlAttribute
-	private final boolean recordPasses;
+	private boolean recordPasses;
 	@XmlAttribute
-	private final int maxFails;
+	private int maxFails;
 	@XmlAttribute
-	private final boolean debug;
+	private boolean debug;
 	@XmlAttribute
-	private final boolean showErrorMessages;
+	private boolean showErrorMessages;
 	@XmlAttribute
-	private final boolean isLogsEnabled;
+	private boolean isLogsEnabled;
 	@XmlAttribute
-	private final String loggingLevel;
+	private String loggingLevel;
 	@XmlAttribute
-	private final int maxNumberOfDisplayedFailedChecks;
+	private int maxNumberOfDisplayedFailedChecks;
 	@XmlAttribute
-	private final boolean showProgress;
+	private boolean showProgress;
 	private final boolean nonPDFExtension;
 
 	private ValidatorConfigImpl() {

--- a/core/src/main/java/org/verapdf/processor/ProcessorConfigImpl.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorConfigImpl.java
@@ -45,19 +45,19 @@ final class ProcessorConfigImpl implements ProcessorConfig {
 	private static final String defaultMdFolder = ".";
 	private static final ProcessorConfig defaultInstance = new ProcessorConfigImpl();
 	@XmlElement
-	private final EnumSet<TaskType> tasks;
+	private EnumSet<TaskType> tasks;
 	@XmlElement
-	private final ValidatorConfig validatorConfig;
+	private ValidatorConfig validatorConfig;
 	@XmlElement
-	private final FeatureExtractorConfig featureConfig;
+	private FeatureExtractorConfig featureConfig;
 	@XmlElement
-	private final PluginsCollectionConfig pluginsCollectionConfig;
+	private PluginsCollectionConfig pluginsCollectionConfig;
 	@XmlElement
-	private final MetadataFixerConfig fixerConfig;
+	private MetadataFixerConfig fixerConfig;
 	@XmlElement
-	private final ValidationProfile customProfile;
+	private ValidationProfile customProfile;
 	@XmlAttribute
-	private final String mdFolder;
+	private String mdFolder;
 
 	private ProcessorConfigImpl() {
 		this(ValidatorFactory.defaultConfig(), FeatureFactory.defaultConfig(),

--- a/core/src/main/java/org/verapdf/processor/ProcessorResultImpl.java
+++ b/core/src/main/java/org/verapdf/processor/ProcessorResultImpl.java
@@ -48,21 +48,21 @@ import org.verapdf.report.FeaturesReport;
 class ProcessorResultImpl implements ProcessorResult {
 	private static final ProcessorResult defaultInstance = new ProcessorResultImpl();
 	@XmlAttribute
-	private final boolean isPdf;
+	private boolean isPdf;
 	@XmlAttribute
-	private final boolean isEncryptedPdf;
+	private boolean isEncryptedPdf;
 	@XmlAttribute
-	private final boolean isOutOfMemory;
+	private boolean isOutOfMemory;
 	@XmlAttribute
-	private final boolean hasException;
+	private boolean hasException;
 	@XmlElement
-	private final ItemDetails itemDetails;
-	private final EnumMap<TaskType, TaskResult> taskResults;
+	private ItemDetails itemDetails;
+	private EnumMap<TaskType, TaskResult> taskResults;
 	@XmlElement
-	private final List<ValidationResult> validationResults;
-	private final FeatureExtractionResult featuresResult;
+	private List<ValidationResult> validationResults;
+	private FeatureExtractionResult featuresResult;
 	@XmlElement
-	private final MetadataFixerResult fixerResult;
+	private MetadataFixerResult fixerResult;
 
 	private ProcessorResultImpl() {
 		this(ItemDetails.defaultInstance(), TaskResultImpl.defaultInstance());

--- a/core/src/main/java/org/verapdf/processor/TaskResultImpl.java
+++ b/core/src/main/java/org/verapdf/processor/TaskResultImpl.java
@@ -48,13 +48,13 @@ class TaskResultImpl implements TaskResult {
 	private final VeraPDFException exception;
 
 	@XmlAttribute
-	private final TaskType type;
+	private TaskType type;
 	@XmlAttribute
-	private final boolean isExecuted;
+	private boolean isExecuted;
 	@XmlAttribute
-	private final boolean isSuccess;
+	private boolean isSuccess;
 	@XmlElement
-	private final AuditDuration duration;
+	private AuditDuration duration;
 
 	@XmlElement
 	public String getExceptionMessage() {

--- a/core/src/main/java/org/verapdf/processor/app/VeraAppConfigImpl.java
+++ b/core/src/main/java/org/verapdf/processor/app/VeraAppConfigImpl.java
@@ -50,17 +50,17 @@ import org.verapdf.processor.FormatOption;
 public final class VeraAppConfigImpl implements VeraAppConfig {
 	private static final VeraAppConfig defaultInstance = AppConfigBuilder.defaultBuilder().build();
 	@XmlAttribute
-	private final ProcessType type;
+	private ProcessType type;
 	@XmlAttribute
-	private final FormatOption format;
+	private FormatOption format;
 	@XmlAttribute
-	private final boolean isVerbose;
+	private boolean isVerbose;
 	@XmlElement
-	private final String fixerFolder;
+	private String fixerFolder;
 	@XmlElement
-	private final String wikiPath;
+	private String wikiPath;
 	@XmlElement
-	private final String policyFile;
+	private String policyFile;
 
 	VeraAppConfigImpl() {
 		this(defaultInstance.getProcessType(), defaultInstance.getFixesFolder(),

--- a/core/src/main/java/org/verapdf/processor/plugins/Attribute.java
+++ b/core/src/main/java/org/verapdf/processor/plugins/Attribute.java
@@ -30,9 +30,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class Attribute {
 
     @XmlAttribute
-    private final String key;
+    private String key;
     @XmlAttribute
-    private final String value;
+    private String value;
 
     private Attribute(String key, String value) {
         this.key = key;

--- a/core/src/main/java/org/verapdf/processor/plugins/PluginConfig.java
+++ b/core/src/main/java/org/verapdf/processor/plugins/PluginConfig.java
@@ -35,18 +35,18 @@ import java.util.List;
 public class PluginConfig {
 
 	@XmlAttribute
-	private final boolean enabled;
+	private boolean enabled;
 	@XmlElement
-	private final String name;
+	private String name;
 	@XmlElement
-	private final String version;
+	private String version;
 	@XmlElement
-	private final String description;
+	private String description;
 	@XmlElement
-	private final String pluginJar;
+	private String pluginJar;
 	@XmlElement(name="attribute")
 	@XmlElementWrapper(name = "attributes")
-	private final List<Attribute> attributes;
+	private List<Attribute> attributes;
 
 	private PluginConfig(boolean enabled, String name, String version, String description, String pluginJar, List<Attribute> attributes) {
 		this.enabled = enabled;

--- a/core/src/main/java/org/verapdf/processor/plugins/PluginsCollectionConfig.java
+++ b/core/src/main/java/org/verapdf/processor/plugins/PluginsCollectionConfig.java
@@ -39,7 +39,7 @@ import java.util.List;
 public final class PluginsCollectionConfig {
 
 	@XmlElement(name = "plugin")
-	private final List<PluginConfig> plugin;
+	private List<PluginConfig> plugin;
 
 	public PluginsCollectionConfig() {
 		this(Collections.emptyList());

--- a/core/src/main/java/org/verapdf/processor/reports/AbstractBatchJobSummary.java
+++ b/core/src/main/java/org/verapdf/processor/reports/AbstractBatchJobSummary.java
@@ -25,9 +25,9 @@ import javax.xml.bind.annotation.XmlValue;
 
 public abstract class AbstractBatchJobSummary implements BatchJobSummary {
 	@XmlValue
-	protected final int totalJobs;
+	protected int totalJobs;
 	@XmlAttribute
-	protected final int failedJobs;
+	protected int failedJobs;
 
 	protected AbstractBatchJobSummary() {
 		this(0, 0);

--- a/core/src/main/java/org/verapdf/processor/reports/BatchSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/BatchSummaryImpl.java
@@ -40,23 +40,23 @@ import org.verapdf.component.Components;
 final class BatchSummaryImpl implements BatchSummary {
 	private static final BatchSummary DEFAULT = new BatchSummaryImpl();
 	@XmlElement
-	private final ValidationBatchSummary validationReports;
+	private ValidationBatchSummary validationReports;
 	@XmlElement
-	private final FeaturesBatchSummary featureReports;
+	private FeaturesBatchSummary featureReports;
 	@XmlElement
-	private final MetadataRepairBatchSummary repairReports;
+	private MetadataRepairBatchSummary repairReports;
 	@XmlElement
-	private final AuditDuration duration;
+	private AuditDuration duration;
 	@XmlAttribute
-	private final int totalJobs;
+	private int totalJobs;
 	@XmlAttribute
-	private final int failedToParse;
+	private int failedToParse;
 	@XmlAttribute
-	private final int encrypted;
+	private int encrypted;
 	@XmlAttribute
-	private final int outOfMemory;
+	private int outOfMemory;
 	@XmlAttribute
-	private final int veraExceptions;
+	private int veraExceptions;
 
 	private BatchSummaryImpl() {
 		this(Components.defaultDuration(), ValidationBatchSummaryImpl.defaultInstance(),

--- a/core/src/main/java/org/verapdf/processor/reports/CheckImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/CheckImpl.java
@@ -46,14 +46,14 @@ import java.util.stream.Collectors;
 
 final class CheckImpl implements Check {
 	@XmlAttribute
-	private final String status;
+	private String status;
 	@XmlElement
-	private final String location;
+	private String location;
 	@XmlElement
-	private final String context;
+	private String context;
 	@XmlElement
-	private final String errorMessage;
-	private final List<String> errorArguments;
+	private String errorMessage;
+	private List<String> errorArguments;
 
 	private CheckImpl(final TestAssertion.Status status, final String context, final String location,
 	                  final String errorMessage, final List<String> errorArguments) {

--- a/core/src/main/java/org/verapdf/processor/reports/FixerReportImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/FixerReportImpl.java
@@ -43,15 +43,15 @@ import org.verapdf.pdfa.results.MetadataFixerResult;
 @XmlRootElement(name = "metadataRepairReport")
 final class FixerReportImpl implements MetadataFixerReport {
 	@XmlAttribute
-	private final String status;
+	private String status;
 	@XmlAttribute
-	private final int fixCount;
+	private int fixCount;
 	@XmlElementWrapper(name="fixes")
 	@XmlElement(name="fix")
-	private final List<String> fixes;
+	private List<String> fixes;
 	@XmlElementWrapper(name="errors")
 	@XmlElement(name="error")
-	private final List<String> errors;
+	private List<String> errors;
 
 	private FixerReportImpl(final String status, final int fixCount, final List<String> fixes,
 			final List<String> errors) {

--- a/core/src/main/java/org/verapdf/processor/reports/ItemDetails.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ItemDetails.java
@@ -39,9 +39,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 public class ItemDetails {
 	static final ItemDetails DEFAULT = new ItemDetails();
 	@XmlElement
-	private final String name;
+	private String name;
 	@XmlAttribute
-	private final long size;
+	private long size;
 
 	private ItemDetails() {
 		this("unknown");

--- a/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/RuleSummaryImpl.java
@@ -42,27 +42,27 @@ import java.util.*;
 final class RuleSummaryImpl implements RuleSummary {
 	private final Status ruleStatus;
 	@XmlAttribute
-	private final String specification;
+	private String specification;
 	@XmlAttribute
-	private final String clause;
+	private String clause;
 	@XmlAttribute
-	private final int testNumber;
+	private int testNumber;
 	@XmlAttribute
-	private final String status;
+	private String status;
 	@XmlAttribute
-	private final Integer passedChecks;
+	private Integer passedChecks;
 	@XmlAttribute
-	private final int failedChecks;
+	private int failedChecks;
 	@XmlAttribute
-	private final String tags;
+	private String tags;
 	@XmlElement
-	private final String description;
+	private String description;
 	@XmlElement
-	private final String object;
+	private String object;
 	@XmlElement
-	private final String test;
+	private String test;
 	@XmlElement(name = "check")
-	private final List<Check> checks;
+	private List<Check> checks;
 
 	private RuleSummaryImpl(final RuleId ruleId, final Status status, final Integer passedChecks, final int failedChecks,
 			final String tags, final String description, final String object, final String test, final List<Check> checks) {

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummaryImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationBatchSummaryImpl.java
@@ -28,9 +28,9 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 final class ValidationBatchSummaryImpl extends AbstractBatchJobSummary implements ValidationBatchSummary {
 	static final ValidationBatchSummary DEFAULT = new ValidationBatchSummaryImpl();
 	@XmlAttribute
-	private final int compliant;
+	private int compliant;
 	@XmlAttribute
-	private final int nonCompliant;
+	private int nonCompliant;
 
 	private ValidationBatchSummaryImpl() {
 		this(0, 0, 0);

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationDetailsImpl.java
@@ -43,18 +43,18 @@ import java.util.*;
 final class ValidationDetailsImpl implements ValidationDetails {
 	private static final ValidationDetailsImpl defaultInstance = new ValidationDetailsImpl();
 	@XmlAttribute
-	private final int passedRules;
+	private int passedRules;
 	@XmlAttribute
-	private final int failedRules;
+	private int failedRules;
 	@XmlAttribute
-	private final int passedChecks;
+	private int passedChecks;
 	@XmlAttribute
-	private final int failedChecks;
+	private int failedChecks;
 
 	private final Set<String> tags;
 
 	@XmlElement(name = "rule")
-	private final Set<RuleSummary> ruleSummaries;
+	private Set<RuleSummary> ruleSummaries;
 
 	private ValidationDetailsImpl() {
 		this(0, 0, 0, 0, Collections.emptySet(), null);

--- a/core/src/main/java/org/verapdf/processor/reports/ValidationReportImpl.java
+++ b/core/src/main/java/org/verapdf/processor/reports/ValidationReportImpl.java
@@ -39,15 +39,15 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 final class ValidationReportImpl implements ValidationReport {
 	private static final ValidationReportImpl defaultInstance = new ValidationReportImpl();
 	@XmlElement
-	private final ValidationDetails details;
+	private ValidationDetails details;
 	@XmlAttribute
-	private final String jobEndStatus;
+	private String jobEndStatus;
 	@XmlAttribute
-	private final String profileName;
+	private String profileName;
 	@XmlAttribute
-	private final String statement;
+	private String statement;
 	@XmlAttribute
-	private final boolean isCompliant;
+	private boolean isCompliant;
 
 	private ValidationReportImpl() {
 		this(ValidationDetailsImpl.defaultInstance(), "Unknown Profile", "Statement", //$NON-NLS-1$ //$NON-NLS-2$

--- a/core/src/main/java/org/verapdf/report/DocumentResourcesFeatures.java
+++ b/core/src/main/java/org/verapdf/report/DocumentResourcesFeatures.java
@@ -31,19 +31,19 @@ import javax.xml.bind.annotation.XmlElement;
 public class DocumentResourcesFeatures {
 
 	@XmlElement
-	private final FeaturesNode graphicsStates;
+	private FeaturesNode graphicsStates;
 	@XmlElement
-	private final FeaturesNode colorSpaces;
+	private FeaturesNode colorSpaces;
 	@XmlElement
-	private final FeaturesNode patterns;
+	private FeaturesNode patterns;
 	@XmlElement
-	private final FeaturesNode shadings;
+	private FeaturesNode shadings;
 	@XmlElement
-	private final FeaturesNode xobjects;
+	private FeaturesNode xobjects;
 	@XmlElement
-	private final FeaturesNode fonts;
+	private FeaturesNode fonts;
 	@XmlElement
-	private final FeaturesNode propertiesDicts;
+	private FeaturesNode propertiesDicts;
 
 	private DocumentResourcesFeatures(FeaturesNode propertiesDicts, FeaturesNode fonts, FeaturesNode xobjects, FeaturesNode shadings, FeaturesNode patterns, FeaturesNode colorSpaces, FeaturesNode graphicsStates) {
 		this.propertiesDicts = propertiesDicts;

--- a/core/src/main/java/org/verapdf/report/FeaturesNode.java
+++ b/core/src/main/java/org/verapdf/report/FeaturesNode.java
@@ -64,9 +64,9 @@ public class FeaturesNode {
 	private static final int CR = 0xD;
 
 	@XmlAnyAttribute
-	private final Map<QName, Object> attributes;
+	private Map<QName, Object> attributes;
 	@XmlMixed
-	private final List<Object> children;
+	private List<Object> children;
 
 	private FeaturesNode(Map<QName, Object> attributes, List<Object> children) {
 		this.attributes = attributes;

--- a/core/src/main/java/org/verapdf/report/FeaturesReport.java
+++ b/core/src/main/java/org/verapdf/report/FeaturesReport.java
@@ -37,37 +37,37 @@ public class FeaturesReport {
 	private static final String ERROR_STATUS = "Could not finish features collecting due to unexpected error."; //$NON-NLS-1$
 
 	@XmlElement
-	private final String status;
+	private String status;
 	@XmlElement
-	private final FeaturesNode informationDict;
+	private FeaturesNode informationDict;
 	@XmlElement
-	private final FeaturesNode metadata;
+	private FeaturesNode metadata;
 	@XmlElement
-	private final FeaturesNode documentSecurity;
+	private FeaturesNode documentSecurity;
 	@XmlElement
-	private final FeaturesNode signatures;
+	private FeaturesNode signatures;
 	@XmlElement
-	private final FeaturesNode lowLevelInfo;
+	private FeaturesNode lowLevelInfo;
 	@XmlElement
-	private final FeaturesNode actions;
+	private FeaturesNode actions;
 	@XmlElement
-	private final FeaturesNode interactiveFormFields;
+	private FeaturesNode interactiveFormFields;
 	@XmlElement
-	private final FeaturesNode embeddedFiles;
+	private FeaturesNode embeddedFiles;
 	@XmlElement
-	private final FeaturesNode iccProfiles;
+	private FeaturesNode iccProfiles;
 	@XmlElement
-	private final FeaturesNode outputIntents;
+	private FeaturesNode outputIntents;
 	@XmlElement
-	private final FeaturesNode outlines;
+	private FeaturesNode outlines;
 	@XmlElement
-	private final FeaturesNode annotations;
+	private FeaturesNode annotations;
 	@XmlElement
-	private final FeaturesNode pages;
+	private FeaturesNode pages;
 	@XmlElement
-	private final DocumentResourcesFeatures documentResources;
+	private DocumentResourcesFeatures documentResources;
 	@XmlElement
-	private final FeaturesNode errors;
+	private FeaturesNode errors;
 
 	private FeaturesReport(FeaturesNode informationDict, FeaturesNode metadata,
 						   FeaturesNode documentSecurity, FeaturesNode signatures,

--- a/core/src/test/java/org/verapdf/ReleaseDetailsTest.java
+++ b/core/src/test/java/org/verapdf/ReleaseDetailsTest.java
@@ -55,7 +55,7 @@ public class ReleaseDetailsTest {
 	 */
 	@Test
 	public final void testHashCodeAndEquals() {
-		EqualsVerifier.forClass(ReleaseDetails.class).verify();
+		EqualsVerifier.simple().forClass(ReleaseDetails.class).verify();
 	}
 
 	/**

--- a/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
+++ b/core/src/test/java/org/verapdf/component/AuditDurationImplTest.java
@@ -35,7 +35,7 @@ public class AuditDurationImplTest {
 	 */
 	@Test
 	public void testHashCodeAndEquals() {
-		EqualsVerifier.forClass(AuditDurationImpl.class).verify();
+		EqualsVerifier.simple().forClass(AuditDurationImpl.class).verify();
 	}
 
 	@Test

--- a/core/src/test/java/org/verapdf/features/FeatureExtractorConfigTest.java
+++ b/core/src/test/java/org/verapdf/features/FeatureExtractorConfigTest.java
@@ -39,7 +39,7 @@ public class FeatureExtractorConfigTest {
 	 */
 	@Test
 	public final void testHashCodeAndEquals() {
-		EqualsVerifier.forClass(FeatureExtractorConfigImpl.class).verify();
+		EqualsVerifier.simple().forClass(FeatureExtractorConfigImpl.class).verify();
 	}
 
 	@Test

--- a/core/src/test/java/org/verapdf/metadata/fixer/FixerConfigTest.java
+++ b/core/src/test/java/org/verapdf/metadata/fixer/FixerConfigTest.java
@@ -47,7 +47,7 @@ public class FixerConfigTest {
 	 */
 	@Test
 	public final void testHashCodeAndEquals() {
-		EqualsVerifier.forClass(FixerConfigImpl.class).verify();
+		EqualsVerifier.simple().forClass(FixerConfigImpl.class).verify();
 	}
 
 	/**

--- a/core/src/test/java/org/verapdf/pdfa/results/LocationTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/LocationTest.java
@@ -42,7 +42,7 @@ public class LocationTest {
      */
     @Test
     public final void testHashCodeAndEquals() {
-        EqualsVerifier.forClass(LocationImpl.class).verify();
+        EqualsVerifier.simple().forClass(LocationImpl.class).verify();
     }
 
     /**

--- a/core/src/test/java/org/verapdf/pdfa/results/MetadataFixerResultTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/MetadataFixerResultTest.java
@@ -35,6 +35,6 @@ public class MetadataFixerResultTest {
 	 */
 	@Test
 	public final void testHashCodeAndEquals() {
-		EqualsVerifier.forClass(MetadataFixerResultImpl.class).suppress(Warning.NULL_FIELDS).verify();
+		EqualsVerifier.simple().forClass(MetadataFixerResultImpl.class).suppress(Warning.NULL_FIELDS).verify();
 	}
 }

--- a/core/src/test/java/org/verapdf/pdfa/results/TestAssertionTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/results/TestAssertionTest.java
@@ -60,7 +60,7 @@ public class TestAssertionTest {
      */
     @Test
     public final void testHashCodeAndEquals() {
-        EqualsVerifier.forClass(TestAssertionImpl.class).withIgnoredFields("ordinal", "errorArguments").verify();
+        EqualsVerifier.simple().forClass(TestAssertionImpl.class).withIgnoredFields("ordinal", "errorArguments").verify();
     }
 
     /**

--- a/core/src/test/java/org/verapdf/pdfa/validation/profiles/ReferenceImplTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/profiles/ReferenceImplTest.java
@@ -42,7 +42,7 @@ public class ReferenceImplTest {
 	 */
 	@Test
 	public final void testEqualsObject() {
-		EqualsVerifier.forClass(ReferenceImpl.class).verify();
+		EqualsVerifier.simple().forClass(ReferenceImpl.class).verify();
 	}
 
 	/**

--- a/core/src/test/java/org/verapdf/pdfa/validation/profiles/RuleIdImplTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/profiles/RuleIdImplTest.java
@@ -42,7 +42,7 @@ public class RuleIdImplTest {
      */
     @Test
     public final void testEqualsObject() {
-        EqualsVerifier.forClass(RuleIdImpl.class).verify();
+        EqualsVerifier.simple().forClass(RuleIdImpl.class).verify();
     }
 
     /**

--- a/core/src/test/java/org/verapdf/pdfa/validation/profiles/RuleImplTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/profiles/RuleImplTest.java
@@ -53,7 +53,7 @@ public class RuleImplTest {
      */
     @Test
     public final void testEqualsObject() {
-        EqualsVerifier.forClass(RuleImpl.class).suppress(Warning.NULL_FIELDS).verify();
+        EqualsVerifier.simple().forClass(RuleImpl.class).suppress(Warning.NULL_FIELDS).verify();
     }
 
     /**

--- a/core/src/test/java/org/verapdf/pdfa/validation/profiles/ValidationProfileImplTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/profiles/ValidationProfileImplTest.java
@@ -53,7 +53,7 @@ public class ValidationProfileImplTest {
 	 */
 	@Test
 	public final void testEqualsObject() {
-		EqualsVerifier.forClass(ValidationProfileImpl.class).withIgnoredFields("ruleLookup", "objectVariableMap", "objectRuleMap", "objectVariableMapLock", "objectRuleMapAndRuleLookupLock").suppress(Warning.NULL_FIELDS).verify();
+		EqualsVerifier.simple().forClass(ValidationProfileImpl.class).withIgnoredFields("ruleLookup", "objectVariableMap", "objectRuleMap", "objectVariableMapLock", "objectRuleMapAndRuleLookupLock").suppress(Warning.NULL_FIELDS).verify();
 	}
 
 	/**

--- a/core/src/test/java/org/verapdf/pdfa/validation/profiles/VariableImplTest.java
+++ b/core/src/test/java/org/verapdf/pdfa/validation/profiles/VariableImplTest.java
@@ -47,7 +47,7 @@ public class VariableImplTest {
      */
     @Test
     public final void testEqualsObject() {
-        EqualsVerifier.forClass(VariableImpl.class).verify();
+        EqualsVerifier.simple().forClass(VariableImpl.class).verify();
     }
 
     /**

--- a/core/src/test/java/org/verapdf/processor/app/VeraAppConfigTest.java
+++ b/core/src/test/java/org/verapdf/processor/app/VeraAppConfigTest.java
@@ -67,7 +67,7 @@ public class VeraAppConfigTest {
     @SuppressWarnings("static-method")
 	@Test
     public final void testHashCodeAndEquals() {
-        EqualsVerifier.forClass(VeraAppConfigImpl.class).verify();
+        EqualsVerifier.simple().forClass(VeraAppConfigImpl.class).verify();
     }
 
 	/**

--- a/core/src/test/java/org/verapdf/processor/reports/ValidationBatchSummaryTest.java
+++ b/core/src/test/java/org/verapdf/processor/reports/ValidationBatchSummaryTest.java
@@ -45,9 +45,9 @@ public class ValidationBatchSummaryTest {
 
     @Test
     public final void testHashCodeAndEquals() {
-        EqualsVerifier.forClass(ValidationBatchSummaryImpl.class).verify();
-        EqualsVerifier.forClass(FeaturesBatchSummary.class).verify();
-        EqualsVerifier.forClass(MetadataRepairBatchSummary.class).verify();
+        EqualsVerifier.simple().forClass(ValidationBatchSummaryImpl.class).verify();
+        EqualsVerifier.simple().forClass(FeaturesBatchSummary.class).verify();
+        EqualsVerifier.simple().forClass(MetadataRepairBatchSummary.class).verify();
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML/JAXB deserialization compatibility across report, validation, processing, configuration, and plugin data.
  * Data fields can now be populated or updated after object creation while preserving existing types, annotations, initialization, and application behavior.
  * Improved handling of unparsable release-date logging.
* **Tests**
  * Updated equality and hash-code verification coverage using simplified verification configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->